### PR TITLE
Feature 11: 사용자 인증 API 도메인 변경

### DIFF
--- a/hobbyroom/app/main.py
+++ b/hobbyroom/app/main.py
@@ -6,6 +6,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import HTMLResponse
 
 from hobbyroom import exceptions
+from hobbyroom.auth.entrypoint import router as auth_router
 from hobbyroom.container import Container
 from hobbyroom.gathering.entrypoint import router as gathering_router
 from hobbyroom.user.entrypoint import router as user_router
@@ -35,6 +36,7 @@ def inject_dependencies(_app: FastAPI) -> None:
 
 
 def add_routers(_app: FastAPI) -> None:
+    _app.include_router(auth_router)
     _app.include_router(user_router)
     _app.include_router(gathering_router)
 

--- a/hobbyroom/auth/command.py
+++ b/hobbyroom/auth/command.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, EmailStr
+
+
+class AuthorizeUser(BaseModel):
+    email: EmailStr
+    password: str

--- a/hobbyroom/auth/dependency.py
+++ b/hobbyroom/auth/dependency.py
@@ -26,6 +26,11 @@ class ServiceContainer(containers.DeclarativeContainer):
         algorithm=settings.jwt_algorithm,
         clock=clock,
     )
+    authorize_user_handler = providers.Factory(
+        service.AuthorizeUserHandler,
+        auth_unit_of_work=adapter.auth_unit_of_work,
+        jwt_handler=jwt_handler,
+    )
 
 
 class AuthContainer(containers.DeclarativeContainer):

--- a/hobbyroom/auth/domain/vo.py
+++ b/hobbyroom/auth/domain/vo.py
@@ -37,6 +37,7 @@ class Persona(BaseModel):
 class User(BaseModel):
     id: UUID
     email: EmailStr
+    password: str | None = None
     personas: list[Persona] = Field(default_factory=list)
 
     @classmethod
@@ -44,6 +45,7 @@ class User(BaseModel):
         return cls(
             id=user_obj.id,
             email=user_obj.email,
+            password=user_obj.password,
             personas=[
                 Persona.model_validate(persona.to_dict())
                 for persona in user_obj.personas

--- a/hobbyroom/auth/entrypoint.py
+++ b/hobbyroom/auth/entrypoint.py
@@ -1,0 +1,32 @@
+import http
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from hobbyroom import constants, exceptions
+from hobbyroom.auth import command, schema, service
+from hobbyroom.container import Container
+
+router = APIRouter()
+
+
+@router.post(
+    "/v1/auth/user",
+    response_model=schema.UserToken,
+    status_code=http.HTTPStatus.OK,
+    tags=[constants.OpenApiTag.AUTH],
+    summary="사용자 계정 인증",
+    description="사용자 계정 정보를 확인하고 인증 정보를 반환합니다.",
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+    ),
+)
+@inject
+async def authorize_user(
+    cmd: command.AuthorizeUser,
+    handler: service.AuthorizeUserHandler = Depends(
+        Provide[Container.auth.service.authorize_user_handler]
+    ),
+):
+    return handler.handle(cmd)

--- a/hobbyroom/auth/schema.py
+++ b/hobbyroom/auth/schema.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class UserToken(BaseModel):
+    token: str

--- a/hobbyroom/auth/service/__init__.py
+++ b/hobbyroom/auth/service/__init__.py
@@ -1,1 +1,2 @@
+from .command_handler import *  # noqa: F401, F403
 from .jwt_handler import *  # noqa: F401, F403

--- a/hobbyroom/auth/service/command_handler.py
+++ b/hobbyroom/auth/service/command_handler.py
@@ -1,0 +1,32 @@
+import bcrypt
+
+from hobbyroom import exceptions
+from hobbyroom.auth import adapter, command, schema
+from hobbyroom.auth.service import jwt_handler
+
+
+class AuthorizeUserHandler:
+    def __init__(
+        self,
+        auth_unit_of_work: adapter.AuthUnitOfWork,
+        jwt_handler: jwt_handler.JWTHandler,
+    ):
+        self.auth_unit_of_work = auth_unit_of_work
+        self.jwt_handler = jwt_handler
+
+    def handle(self, cmd: command.AuthorizeUser) -> schema.UserToken:
+        with self.auth_unit_of_work as uow:
+            user = uow.user.find_by_email(cmd.email)
+        if not user:
+            raise exceptions.NotFoundError("User not found")
+        self._validate_password(password=cmd.password, hashed_password=user.password)
+        token = self.jwt_handler.issue(user_email=user.email)
+        return schema.UserToken(token=token)
+
+    def _validate_password(self, password: str, hashed_password: str) -> None:
+        is_valid = bcrypt.checkpw(
+            password=password.encode(),
+            hashed_password=hashed_password.encode(),
+        )
+        if not is_valid:
+            raise exceptions.UnauthorizedError("Invalid password")

--- a/hobbyroom/constants.py
+++ b/hobbyroom/constants.py
@@ -2,5 +2,6 @@ import enum
 
 
 class OpenApiTag(enum.StrEnum):
+    AUTH = enum.auto()
     USER = enum.auto()
     GATHERING = enum.auto()

--- a/hobbyroom/container.py
+++ b/hobbyroom/container.py
@@ -13,8 +13,9 @@ class Container(containers.DeclarativeContainer):
     wiring_config = containers.WiringConfiguration(
         modules=[
             ".depends",
-            ".user.entrypoint",
+            ".auth.entrypoint",
             ".gathering.entrypoint",
+            ".user.entrypoint",
         ]
     )
 
@@ -43,5 +44,4 @@ class Container(containers.DeclarativeContainer):
         session_factory=db_session_factory,
         id_generator=id_generator,
         clock=clock,
-        jwt_handler=auth.service.jwt_handler,
     )

--- a/hobbyroom/user/command.py
+++ b/hobbyroom/user/command.py
@@ -15,11 +15,6 @@ class CreateUser(BaseModel):
         ).decode()
 
 
-class AuthorizeUser(BaseModel):
-    email: EmailStr
-    password: str
-
-
 class CreatePersona(BaseModel):
     name: str
     user_id: UUID | None = None

--- a/hobbyroom/user/dependency.py
+++ b/hobbyroom/user/dependency.py
@@ -20,18 +20,12 @@ class ServiceContainer(containers.DeclarativeContainer):
     adapter = providers.DependenciesContainer()
     id_generator = providers.Dependency()
     clock = providers.Dependency()
-    jwt_handler = providers.Dependency()
 
     create_user_handler = providers.Factory(
         service.CreateUserHandler,
         user_unit_of_work=adapter.user_unit_of_work,
         id_generator=id_generator,
         clock=clock,
-    )
-    authorize_user_handler = providers.Factory(
-        service.AuthorizeUserHandler,
-        user_unit_of_work=adapter.user_unit_of_work,
-        jwt_handler=jwt_handler,
     )
     create_persona_handler = providers.Factory(
         service.CreatePersonaHandler,
@@ -45,7 +39,6 @@ class UserContainer(containers.DeclarativeContainer):
     session_factory = providers.Dependency()
     id_generator = providers.Dependency()
     clock = providers.Dependency()
-    jwt_handler = providers.Dependency()
 
     adapter = providers.Container(
         AdapterContainer,
@@ -56,5 +49,4 @@ class UserContainer(containers.DeclarativeContainer):
         adapter=adapter,
         id_generator=id_generator,
         clock=clock,
-        jwt_handler=jwt_handler,
     )

--- a/hobbyroom/user/entrypoint.py
+++ b/hobbyroom/user/entrypoint.py
@@ -28,28 +28,6 @@ async def create_user(
     return Response(status_code=http.HTTPStatus.CREATED)
 
 
-@router.post(
-    "/v1/users/auth",
-    response_model=schema.UserToken,
-    status_code=http.HTTPStatus.OK,
-    tags=[constants.OpenApiTag.USER],
-    summary="사용자 계정 인증",
-    description="사용자 계정 정보를 확인하고 인증 정보를 반환합니다.",
-    responses=exceptions.get_responses(
-        http.HTTPStatus.UNPROCESSABLE_ENTITY,
-        http.HTTPStatus.UNAUTHORIZED,
-    ),
-)
-@inject
-async def authorize_user(
-    cmd: command.AuthorizeUser,
-    handler: service.AuthorizeUserHandler = Depends(
-        Provide[Container.user.service.authorize_user_handler]
-    ),
-):
-    return handler.handle(cmd)
-
-
 @router.get(
     "/v1/users/me",
     response_model=schema.UserInfo,

--- a/hobbyroom/user/schema/response.py
+++ b/hobbyroom/user/schema/response.py
@@ -5,10 +5,6 @@ from pydantic import BaseModel, EmailStr
 from hobbyroom import auth
 
 
-class UserToken(BaseModel):
-    token: str
-
-
 class UserPersona(BaseModel):
     id: str
     name: str

--- a/hobbyroom/user/service/command_handler.py
+++ b/hobbyroom/user/service/command_handler.py
@@ -1,11 +1,9 @@
 from collections.abc import Callable
 from uuid import UUID
 
-import bcrypt
 import pendulum
 
-from hobbyroom import auth, exceptions
-from hobbyroom.user import adapter, command, domain, schema
+from hobbyroom.user import adapter, command, domain
 
 
 class CreateUserHandler:
@@ -29,33 +27,6 @@ class CreateUserHandler:
         with self.user_unit_of_work as uow:
             uow.user.add(user)
             uow.commit()
-
-
-class AuthorizeUserHandler:
-    def __init__(
-        self,
-        user_unit_of_work: adapter.UserUnitOfWork,
-        jwt_handler: auth.JWTHandler,
-    ):
-        self.user_unit_of_work = user_unit_of_work
-        self.jwt_handler = jwt_handler
-
-    def handle(self, cmd: command.AuthorizeUser) -> schema.UserToken:
-        with self.user_unit_of_work as uow:
-            user = uow.user.find_by_email(cmd.email)
-        if not user:
-            raise exceptions.NotFoundError("User not found")
-        self._validate_password(password=cmd.password, hashed_password=user.password)
-        token = self.jwt_handler.issue(user_email=user.email)
-        return schema.UserToken(token=token)
-
-    def _validate_password(self, password: str, hashed_password: str) -> None:
-        is_valid = bcrypt.checkpw(
-            password=password.encode(),
-            hashed_password=hashed_password.encode(),
-        )
-        if not is_valid:
-            raise exceptions.UnauthorizedError("Invalid password")
 
 
 class CreatePersonaHandler:


### PR DESCRIPTION
## 요약
사용자 인증을 `user` 도메인 대신 `auth` 도메인에서 처리하도록 수정합니다.

## 변경사항
- 사용자 인증 관련 커맨드, 커맨드 핸들러, 스키마 등의 모듈을 `user`에서 `auth` 도메인 아래로 이동시킵니다.
- `auth` 도메인 라우터를 추가합니다.
- 사용자 인증 엔드포인트 주소가 `/v1/users/auth` 에서 `/v1/auth/user`로 변경됩니다.