### PR TITLE
Feature 15: 페르소나 소속 인증 방식 수정

### DIFF
--- a/hobbyroom/auth/domain/vo.py
+++ b/hobbyroom/auth/domain/vo.py
@@ -5,7 +5,7 @@ from uuid import UUID
 import pendulum
 from pydantic import BaseModel, EmailStr, Field
 
-from hobbyroom import database
+from hobbyroom import database, exceptions
 from hobbyroom.settings import settings
 
 
@@ -56,15 +56,23 @@ class JWTPayload(BaseModel):
 class Persona(BaseModel):
     id: UUID
     name: str
-    gathering_ids: list[UUID] | None = None
+    _gathering_id: UUID | None = None
 
-    def add_gathering_ids(self, affiliated_gatherings: list[str]) -> None:
-        self.gathering_ids = [UUID(id) for id in affiliated_gatherings]
+    @property
+    def gathering_id(self) -> UUID:
+        if self._gathering_id is None:
+            raise exceptions.DomainValidationError("현재 모임 정보가 없습니다.")
+        return self._gathering_id
 
-    def is_affiliated(self, gathering_id: UUID) -> bool:
-        if self.gathering_ids is None:
-            return False
-        return gathering_id in self.gathering_ids
+    def add_gathering_id(
+        self, affiliated_gathering_ids: list[str], current_gathering_id: UUID
+    ) -> None:
+        gathering_ids = [UUID(id) for id in affiliated_gathering_ids]
+        if current_gathering_id not in gathering_ids:
+            raise exceptions.UnauthorizedError(
+                "현재 모임 정보에 소속되어 있지 않은 페르소나입니다."
+            )
+        self._gathering_id = current_gathering_id
 
 
 class User(BaseModel):

--- a/hobbyroom/depends.py
+++ b/hobbyroom/depends.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends
 
@@ -26,6 +28,7 @@ def get_current_user(
 
 @inject
 def get_current_persona(
+    gathering_id: UUID | None = None,
     token: str = Depends(auth.persona_oauth2_schema),
     jwt_handler: auth.JWTHandler = Depends(Provide[Container.auth.service.jwt_handler]),
     auth_unit_of_work: auth.AuthUnitOfWork = Depends(
@@ -46,5 +49,9 @@ def get_current_persona(
                 "페르소나 인증 정보가 유효하지 않습니다."
             )
 
-    persona.add_gathering_ids(affiliated_gatherings=payload.affiliated_gatherings)
+    if gathering_id is not None:
+        persona.add_gathering_id(
+            affiliated_gathering_ids=payload.affiliated_gatherings,
+            current_gathering_id=gathering_id,
+        )
     return persona

--- a/hobbyroom/gathering/command.py
+++ b/hobbyroom/gathering/command.py
@@ -28,12 +28,9 @@ class JoinGathering(InitialGatheringCommand):
 class CreatePost(BaseModel):
     title: str
     content: str
-    gathering_id: UUID
+    gathering_id: UUID | None = None
     persona_id: UUID | None = None
 
-    def add_persona_id(self, persona: auth.Persona) -> None:
-        if not persona.is_affiliated(self.gathering_id):
-            raise exceptions.UnauthorizedError(
-                "해당 모임에 소속되지 않은 페르소나입니다."
-            )
+    def add_affiliation_info(self, persona: auth.Persona) -> None:
+        self.gathering_id = persona.gathering_id
         self.persona_id = persona.id

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -62,7 +62,7 @@ async def join_gathering(
 
 
 @router.post(
-    "/v1/gatherings/posts",
+    "/v1/gatherings/{gathering_id}/posts",
     status_code=http.HTTPStatus.CREATED,
     summary="게시글 작성",
     description="모임에 게시글을 작성합니다.",
@@ -81,6 +81,6 @@ async def create_post(
         Provide[Container.gathering.service.create_post_handler]
     ),
 ):
-    cmd.add_persona_id(persona=persona)
+    cmd.add_affiliation_info(persona=persona)
     handler.handle(cmd)
     return Response(status_code=http.HTTPStatus.CREATED)


### PR DESCRIPTION
## 요약
현재 페르소나의 소속 모임 인증 과정을 수정합니다.

## 변경사항
- 페르소나 인증을 위한 함수에서 모임 id를 파라미터로 받아 소속 인증을 처리하도록 수정합니다.
- `auth` 도메인의 `Persona` 객체가 소속되어 있는 전체 모임 id 리스트 대신 현재 요청을 처리하기 위해 필요한 모임 정보만을 가지도록 수정합니다.
- 모임 게시물 생성 엔드포인트가 수정됩니다.
  - `POST /v1/gatherings/{gathering_id}/posts`
    ```tsx
    interface CreatePost {
      title: string;
      content: string;
    }
    ```