### PR TITLE
Feature 16: 모임 게시물 조회 API 추가

### DIFF
--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -1,7 +1,10 @@
 from uuid import UUID
 
+from sqlalchemy import asc, desc
+from sqlalchemy.orm import selectinload
+
 from hobbyroom import database
-from hobbyroom.gathering import domain
+from hobbyroom.gathering import domain, query
 
 
 class GatheringRepository(database.SQLAlchemyRepository[domain.Gathering]):
@@ -19,3 +22,29 @@ class AffiliationRepository(database.SQLAlchemyRepository[domain.Affiliation]):
 
 class PostRepository(database.SQLAlchemyRepository[domain.Post]):
     __model_cls__ = database.Post
+
+    def list_by_query(self, query: query.ListPosts) -> list[domain.SearchedPost]:
+        order_by = asc(database.Post.created_at) if query.ascending else desc(database.Post.created_at)
+        posts = (
+            self.session.query(database.Post)
+            .filter_by(gathering_id=query.gathering_id)
+            .order_by(order_by)
+            .offset(query.offset)
+            .limit(query.per_page)
+            .options(selectinload(database.Post.persona))
+            .all()
+        )
+        return [
+            domain.SearchedPost(
+                id=post.id,
+                title=post.title,
+                content=post.content,
+                writer=post.persona.name,
+                created_at=post.created_at,
+                updated_at=post.updated_at,
+            )
+            for post in posts
+        ]
+
+    def count_total_per_gathering(self, gathering_id: UUID) -> int:
+        return self.session.query(database.Post).filter_by(gathering_id=gathering_id).count()

--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -24,7 +24,11 @@ class PostRepository(database.SQLAlchemyRepository[domain.Post]):
     __model_cls__ = database.Post
 
     def list_by_query(self, query: query.ListPosts) -> list[domain.SearchedPost]:
-        order_by = asc(database.Post.created_at) if query.ascending else desc(database.Post.created_at)
+        order_by = (
+            asc(database.Post.created_at)
+            if query.ascending
+            else desc(database.Post.created_at)
+        )
         posts = (
             self.session.query(database.Post)
             .filter_by(gathering_id=query.gathering_id)
@@ -47,4 +51,27 @@ class PostRepository(database.SQLAlchemyRepository[domain.Post]):
         ]
 
     def count_total_per_gathering(self, gathering_id: UUID) -> int:
-        return self.session.query(database.Post).filter_by(gathering_id=gathering_id).count()
+        return (
+            self.session.query(database.Post)
+            .filter_by(gathering_id=gathering_id)
+            .count()
+        )
+
+    def find_by_gathering_and_post_id(
+        self, gathering_id: UUID, post_id: UUID
+    ) -> domain.SearchedPost | None:
+        post = (
+            self.session.query(database.Post)
+            .filter_by(gathering_id=gathering_id, id=post_id)
+            .first()
+        )
+        if post:
+            return domain.SearchedPost(
+                id=post.id,
+                title=post.title,
+                content=post.content,
+                writer=post.persona.name,
+                created_at=post.created_at,
+                updated_at=post.updated_at,
+            )
+        return None

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -45,6 +45,10 @@ class ServiceContainer(containers.DeclarativeContainer):
         service.ListPostsHandler,
         gathering_unit_of_work=adapter.gathering_unit_of_work,
     )
+    retrieve_post_handler = providers.Factory(
+        service.RetrievePostHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -41,6 +41,10 @@ class ServiceContainer(containers.DeclarativeContainer):
         id_generator=id_generator,
         clock=clock,
     )
+    list_posts_handler = providers.Factory(
+        service.ListPostsHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/domain/__init__.py
+++ b/hobbyroom/gathering/domain/__init__.py
@@ -1,1 +1,2 @@
 from .model import *  # noqa: F401, F403
+from .vo import *  # noqa: F401, F403

--- a/hobbyroom/gathering/domain/vo.py
+++ b/hobbyroom/gathering/domain/vo.py
@@ -1,0 +1,13 @@
+import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class SearchedPost(BaseModel):
+    id: UUID
+    title: str
+    content: str
+    writer: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -7,7 +7,7 @@ from fastapi.routing import APIRouter
 
 from hobbyroom import auth, constants, depends, exceptions
 from hobbyroom.container import Container
-from hobbyroom.gathering import command, query, schema, service
+from hobbyroom.gathering import command, domain, query, schema, service
 
 router = APIRouter()
 
@@ -116,5 +116,34 @@ async def list_posts(
         ascending=ascending,
         page=page,
         per_page=per_page,
+    )
+    return handler.handle(qry)
+
+
+@router.get(
+    "/v1/gatherings/{gathering_id}/posts/{post_id}",
+    response_model=domain.SearchedPost,
+    status_code=http.HTTPStatus.OK,
+    summary="게시글 조회",
+    description="모임에 작성된 게시글을 조회합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+        http.HTTPStatus.NOT_FOUND,
+    ),
+    dependencies=[Depends(depends.get_current_persona)],
+)
+@inject
+async def retrieve_post(
+    gathering_id: UUID,
+    post_id: UUID,
+    handler: service.RetrievePostHandler = Depends(
+        Provide[Container.gathering.service.retrieve_post_handler]
+    ),
+):
+    qry = query.RetrievePost(
+        gathering_id=gathering_id,
+        post_id=post_id,
     )
     return handler.handle(qry)

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -1,4 +1,5 @@
 import http
+from uuid import UUID
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, Response
@@ -6,7 +7,7 @@ from fastapi.routing import APIRouter
 
 from hobbyroom import auth, constants, depends, exceptions
 from hobbyroom.container import Container
-from hobbyroom.gathering import command, service
+from hobbyroom.gathering import command, query, schema, service
 
 router = APIRouter()
 
@@ -84,3 +85,36 @@ async def create_post(
     cmd.add_affiliation_info(persona=persona)
     handler.handle(cmd)
     return Response(status_code=http.HTTPStatus.CREATED)
+
+
+@router.get(
+    "/v1/gatherings/{gathering_id}/posts",
+    response_model=schema.ListedPosts,
+    status_code=http.HTTPStatus.OK,
+    summary="게시글 목록 조회",
+    description="모임에 작성된 게시글 목록을 조회합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+        http.HTTPStatus.NOT_FOUND,
+    ),
+    dependencies=[Depends(depends.get_current_persona)],
+)
+@inject
+async def list_posts(
+    gathering_id: UUID,
+    ascending: bool = False,
+    page: int = 1,
+    per_page: int = 10,
+    handler: service.ListPostsHandler = Depends(
+        Provide[Container.gathering.service.list_posts_handler]
+    ),
+):
+    qry = query.ListPosts(
+        gathering_id=gathering_id,
+        ascending=ascending,
+        page=page,
+        per_page=per_page,
+    )
+    return handler.handle(qry)

--- a/hobbyroom/gathering/query.py
+++ b/hobbyroom/gathering/query.py
@@ -1,0 +1,14 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ListPosts(BaseModel):
+    gathering_id: UUID
+    ascending: bool
+    page: int = Field(ge=1)
+    per_page: int = Field(le=100)
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.per_page

--- a/hobbyroom/gathering/query.py
+++ b/hobbyroom/gathering/query.py
@@ -12,3 +12,8 @@ class ListPosts(BaseModel):
     @property
     def offset(self) -> int:
         return (self.page - 1) * self.per_page
+
+
+class RetrievePost(BaseModel):
+    gathering_id: UUID
+    post_id: UUID

--- a/hobbyroom/gathering/schema/__init__.py
+++ b/hobbyroom/gathering/schema/__init__.py
@@ -1,0 +1,1 @@
+from .response import *  # noqa: F401, F403

--- a/hobbyroom/gathering/schema/response.py
+++ b/hobbyroom/gathering/schema/response.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from hobbyroom.gathering import domain
+
+
+class ListedPosts(BaseModel):
+    total: int
+    posts: list[domain.SearchedPost]

--- a/hobbyroom/gathering/service/__init__.py
+++ b/hobbyroom/gathering/service/__init__.py
@@ -1,1 +1,2 @@
 from .command_handler import *  # noqa: F401, F403
+from .query_handler import *  # noqa: F401, F403

--- a/hobbyroom/gathering/service/query_handler.py
+++ b/hobbyroom/gathering/service/query_handler.py
@@ -1,0 +1,17 @@
+from hobbyroom import exceptions
+from hobbyroom.gathering import adapter, query, schema
+
+
+class ListPostsHandler:
+    def __init__(self, gathering_unit_of_work: adapter.GatheringUnitOfWork):
+        self.gathering_unit_of_work = gathering_unit_of_work
+
+    def handle(self, query: query.ListPosts) -> schema.ListedPosts:
+        with self.gathering_unit_of_work as uow:
+            gathering = uow.gathering.find_by_id(query.gathering_id)
+            if not gathering:
+                raise exceptions.NotFoundError("존재하지 않는 모임입니다.")
+            total = uow.post.count_total_per_gathering(query.gathering_id)
+            posts = uow.post.list_by_query(query)
+
+        return schema.ListedPosts(total=total, posts=posts)

--- a/hobbyroom/gathering/service/query_handler.py
+++ b/hobbyroom/gathering/service/query_handler.py
@@ -1,5 +1,5 @@
 from hobbyroom import exceptions
-from hobbyroom.gathering import adapter, query, schema
+from hobbyroom.gathering import adapter, domain, query, schema
 
 
 class ListPostsHandler:
@@ -15,3 +15,17 @@ class ListPostsHandler:
             posts = uow.post.list_by_query(query)
 
         return schema.ListedPosts(total=total, posts=posts)
+
+
+class RetrievePostHandler:
+    def __init__(self, gathering_unit_of_work: adapter.GatheringUnitOfWork):
+        self.gathering_unit_of_work = gathering_unit_of_work
+
+    def handle(self, query: query.RetrievePost) -> domain.SearchedPost:
+        with self.gathering_unit_of_work as uow:
+            post = uow.post.find_by_gathering_and_post_id(
+                gathering_id=query.gathering_id, post_id=query.post_id
+            )
+            if post is None:
+                raise exceptions.NotFoundError("존재하지 않는 게시글입니다.")
+        return post


### PR DESCRIPTION
##요약
모임 내에 작성된 게시물의 개별 및 전체 조회 API를 구현합니다.

## 변경사항
- `GET /v1/gatherings/:gathering_id/posts` 게시물 리스트 조회 엔드포인트가 추가됩니다.
  - 쿼리 파라미터 
    - `ascending: bool`  작성일 기준 오름차순 정렬 여부
    - `page: int`  조회할 게시물 목록 페이지 번호
    - `per_page: int`  페이지 당 표시할 게시물 개수
- `GET /v1/gatherings/:gathering_id/posts/:post_id` 개별 게시물 조회 엔드포인트가 추가됩니다.