### PR TITLE
Feature 17: 게시물 삭제 & 업데이트 API 추가

### DIFF
--- a/hobbyroom/database/repository.py
+++ b/hobbyroom/database/repository.py
@@ -2,6 +2,7 @@ from typing import ClassVar, Generic, TypeVar, get_args
 from uuid import UUID
 
 from pydantic import BaseModel
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
 from hobbyroom.database import model
@@ -35,3 +36,7 @@ class SQLAlchemyRepository(Generic[EntityType]):
         entity_type: EntityType = get_args(self.__class__.__orig_bases__[0])[0]
         objs = self.session.query(self.__model_cls__).filter_by(**kwargs).all()
         return [entity_type.model_validate(obj.to_dict()) for obj in objs]
+
+    def delete(self, id: UUID) -> None:
+        stmt = delete(self.__model_cls__).where(self.__model_cls__.id == id)
+        self.session.execute(stmt)

--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
-from sqlalchemy import asc, desc
+import pendulum
+from sqlalchemy import asc, desc, update
 from sqlalchemy.orm import selectinload
 
 from hobbyroom import database
@@ -75,3 +76,14 @@ class PostRepository(database.SQLAlchemyRepository[domain.Post]):
                 updated_at=post.updated_at,
             )
         return None
+
+    def update_post(
+        self, post_id: UUID, title: str, content: str, updated_at: pendulum.DateTime
+    ) -> None:
+        stmt = (
+            update(database.Post)
+            .where(database.Post.id == post_id)
+            .values(title=title, content=content, updated_at=updated_at)
+            .execution_options(synchronize_session="fetch")
+        )
+        self.session.execute(stmt)

--- a/hobbyroom/gathering/command.py
+++ b/hobbyroom/gathering/command.py
@@ -34,3 +34,24 @@ class CreatePost(BaseModel):
     def add_affiliation_info(self, persona: auth.Persona) -> None:
         self.gathering_id = persona.gathering_id
         self.persona_id = persona.id
+
+
+class UpdatePost(BaseModel):
+    title: str | None = None
+    content: str | None = None
+    post_id: UUID | None = None
+    gathering_id: UUID | None = None
+    persona_id: UUID | None = None
+
+    @property
+    def has_entity_ids(self) -> bool:
+        return (
+            self.post_id is not None
+            and self.gathering_id is not None
+            and self.persona_id is not None
+        )
+
+    def add_entity_ids(self, post_id: UUID, persona: auth.Persona) -> None:
+        self.post_id = post_id
+        self.gathering_id = persona.gathering_id
+        self.persona_id = persona.id

--- a/hobbyroom/gathering/command.py
+++ b/hobbyroom/gathering/command.py
@@ -55,3 +55,9 @@ class UpdatePost(BaseModel):
         self.post_id = post_id
         self.gathering_id = persona.gathering_id
         self.persona_id = persona.id
+
+
+class DeletePost(BaseModel):
+    post_id: UUID
+    gathering_id: UUID
+    persona_id: UUID

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -49,6 +49,11 @@ class ServiceContainer(containers.DeclarativeContainer):
         service.RetrievePostHandler,
         gathering_unit_of_work=adapter.gathering_unit_of_work,
     )
+    update_post_handler = providers.Factory(
+        service.UpdatePostHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+        clock=clock,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -54,6 +54,10 @@ class ServiceContainer(containers.DeclarativeContainer):
         gathering_unit_of_work=adapter.gathering_unit_of_work,
         clock=clock,
     )
+    delete_post_handler = providers.Factory(
+        service.DeletePostHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -174,3 +174,32 @@ async def update_post(
     cmd.add_entity_ids(post_id=post_id, persona=persona)
     handler.handle(cmd)
     return Response(status_code=http.HTTPStatus.OK)
+
+
+@router.delete(
+    "/v1/gatherings/{gathering_id}/posts/{post_id}",
+    status_code=http.HTTPStatus.NO_CONTENT,
+    summary="게시글 삭제",
+    description="모임에 작성된 게시글을 삭제합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+        http.HTTPStatus.NOT_FOUND,
+    ),
+)
+@inject
+async def delete_post(
+    post_id: UUID,
+    persona: auth.Persona = Depends(depends.get_current_persona),
+    handler: service.DeletePostHandler = Depends(
+        Provide[Container.gathering.service.delete_post_handler]
+    ),
+):
+    cmd = command.DeletePost(
+        post_id=post_id,
+        gathering_id=persona.gathering_id,
+        persona_id=persona.id,
+    )
+    handler.handle(cmd)
+    return Response(status_code=http.HTTPStatus.NO_CONTENT)

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -147,3 +147,30 @@ async def retrieve_post(
         post_id=post_id,
     )
     return handler.handle(qry)
+
+
+@router.patch(
+    "/v1/gatherings/{gathering_id}/posts/{post_id}",
+    status_code=http.HTTPStatus.OK,
+    summary="게시글 수정",
+    description="모임에 작성된 게시글을 수정합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+        http.HTTPStatus.NOT_FOUND,
+    ),
+)
+@inject
+async def update_post(
+    gathering_id: UUID,
+    post_id: UUID,
+    cmd: command.UpdatePost,
+    persona: auth.Persona = Depends(depends.get_current_persona),
+    handler: service.UpdatePostHandler = Depends(
+        Provide[Container.gathering.service.update_post_handler]
+    ),
+):
+    cmd.add_entity_ids(post_id=post_id, persona=persona)
+    handler.handle(cmd)
+    return Response(status_code=http.HTTPStatus.OK)

--- a/hobbyroom/gathering/service/command_handler.py
+++ b/hobbyroom/gathering/service/command_handler.py
@@ -119,3 +119,19 @@ class UpdatePostHandler:
                 updated_at=self.clock(),
             )
             uow.commit()
+
+
+class DeletePostHandler:
+    def __init__(
+        self,
+        gathering_unit_of_work: adapter.GatheringUnitOfWork,
+    ):
+        self.gathering_unit_of_work = gathering_unit_of_work
+
+    def handle(self, cmd: command.DeletePost) -> None:
+        with self.gathering_unit_of_work as uow:
+            post = uow.post.find_by_id(cmd.post_id)
+            if post is None or post.gathering_id != cmd.gathering_id:
+                raise exceptions.NotFoundError("게시글을 찾을 수 없습니다.")
+            uow.post.delete(post.id)
+            uow.commit()

--- a/hobbyroom/gathering/service/command_handler.py
+++ b/hobbyroom/gathering/service/command_handler.py
@@ -92,3 +92,30 @@ class CreatePostHandler:
             )
             uow.post.add(post)
             uow.commit()
+
+
+class UpdatePostHandler:
+    def __init__(
+        self,
+        gathering_unit_of_work: adapter.GatheringUnitOfWork,
+        clock: Callable[..., pendulum.DateTime],
+    ):
+        self.gathering_unit_of_work = gathering_unit_of_work
+        self.clock = clock
+
+    def handle(self, cmd: command.UpdatePost) -> None:
+        if not cmd.has_entity_ids:
+            raise exceptions.DomainValidationError(
+                "게시글 수정을 위한 정보가 입력되지 않았습니다."
+            )
+        with self.gathering_unit_of_work as uow:
+            post = uow.post.find_by_id(cmd.post_id)
+            if post is None or post.gathering_id != cmd.gathering_id:
+                raise exceptions.NotFoundError("게시글을 찾을 수 없습니다.")
+            uow.post.update_post(
+                post_id=post.id,
+                title=cmd.title or post.title,
+                content=cmd.content or post.content,
+                updated_at=self.clock(),
+            )
+            uow.commit()


### PR DESCRIPTION
## 요약
모임 게시물의 내용을 수정하는 API와 삭제 API를 구현합니다.

## 변경사항
- `PATCH /v1/gatherings/:gathering_id/posts/:post_id` 엔드포인트가 추가됩니다.
  - 요청
    ```tsx
    interface UpdatePost {
      title: string | null;
      content: string | null;
    }
    ``` 
- `DELETE /v1/gatherings/:gathering_id/posts/:post_id` 엔드포인트가 추가됩니다.
- 각 동작을 위한 커맨드와 커맨드 핸들러가 추가됩니다.
- 엔티티 업데이트 및 삭제를 위한 레포지토리 메소드가 추가됩니다.