### PR TITLE
Feature 20: 모임 목록 반환 API 추가

### DIFF
--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -11,6 +11,33 @@ from hobbyroom.gathering import domain, query
 class GatheringRepository(database.SQLAlchemyRepository[domain.Gathering]):
     __model_cls__ = database.Gathering
 
+    def list_by_query(self, query: query.ListGatherings) -> list[domain.Gathering]:
+        order_by = (
+            asc(database.Gathering.created_at)
+            if query.ascending
+            else desc(database.Gathering.created_at)
+        )
+        gatherings = (
+            self.session.query(database.Gathering)
+            .order_by(order_by)
+            .offset(query.offset)
+            .limit(query.per_page)
+            .all()
+        )
+        return [
+            domain.Gathering(
+                id=gathering.id,
+                name=gathering.name,
+                description=gathering.description,
+                created_at=gathering.created_at,
+                updated_at=gathering.updated_at,
+            )
+            for gathering in gatherings
+        ]
+
+    def count_total(self) -> int:
+        return self.session.query(database.Gathering).count()
+
 
 class AffiliationRepository(database.SQLAlchemyRepository[domain.Affiliation]):
     __model_cls__ = database.Affiliation

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -58,6 +58,10 @@ class ServiceContainer(containers.DeclarativeContainer):
         service.DeletePostHandler,
         gathering_unit_of_work=adapter.gathering_unit_of_work,
     )
+    list_gatherings_handler = providers.Factory(
+        service.ListGatheringsHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -62,6 +62,34 @@ async def join_gathering(
     return Response(status_code=http.HTTPStatus.CREATED)
 
 
+@router.get(
+    "/v1/gatherings",
+    response_model=schema.ListedGatherings,
+    status_code=http.HTTPStatus.OK,
+    summary="모임 목록 조회",
+    description="생성되어 있는 모임들의 목록을 반환합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+    ),
+)
+@inject
+async def list_gatherings(
+    ascending: bool = False,
+    page: int = 1,
+    per_page: int = 10,
+    handler: service.ListGatheringsHandler = Depends(
+        Provide[Container.gathering.service.list_gatherings_handler]
+    ),
+):
+    qry = query.ListGatherings(
+        ascending=ascending,
+        page=page,
+        per_page=per_page,
+    )
+    return handler.handle(qry)
+
+
 @router.post(
     "/v1/gatherings/{gathering_id}/posts",
     status_code=http.HTTPStatus.CREATED,

--- a/hobbyroom/gathering/query.py
+++ b/hobbyroom/gathering/query.py
@@ -3,6 +3,16 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+class ListGatherings(BaseModel):
+    ascending: bool = False
+    page: int = Field(ge=1, default=1)
+    per_page: int = Field(le=100, default=10)
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.per_page
+
+
 class ListPosts(BaseModel):
     gathering_id: UUID
     ascending: bool

--- a/hobbyroom/gathering/schema/response.py
+++ b/hobbyroom/gathering/schema/response.py
@@ -3,6 +3,11 @@ from pydantic import BaseModel
 from hobbyroom.gathering import domain
 
 
+class ListedGatherings(BaseModel):
+    total: int
+    gatherings: list[domain.Gathering]
+
+
 class ListedPosts(BaseModel):
     total: int
     posts: list[domain.SearchedPost]

--- a/hobbyroom/gathering/service/query_handler.py
+++ b/hobbyroom/gathering/service/query_handler.py
@@ -29,3 +29,15 @@ class RetrievePostHandler:
             if post is None:
                 raise exceptions.NotFoundError("존재하지 않는 게시글입니다.")
         return post
+
+
+class ListGatheringsHandler:
+    def __init__(self, gathering_unit_of_work: adapter.GatheringUnitOfWork):
+        self.gathering_unit_of_work = gathering_unit_of_work
+
+    def handle(self, query: query.ListGatherings) -> schema.ListedGatherings:
+        with self.gathering_unit_of_work as uow:
+            total = uow.gathering.count_total()
+            gatherings = uow.gathering.list_by_query(query)
+
+        return schema.ListedGatherings(total=total, gatherings=gatherings)


### PR DESCRIPTION
## 요약
서비스에 등록되어 있는 모임들의 목록을 반환하는 API를 추가합니다.

## 변경사항
- 모임 목록을 페이지네이션을 사용하여 반환하도록 쿼리 및 쿼리핸들러를 구성합니다.
  - 모임 목록 반환 레포지토리 메소드가 추가됩니다.
- `GET /v1/gatherings` 엔드포인트가 추가됩니다.
  - 쿼리 파라미터
    - ascending: bool 작성일 기준 오름차순 정렬 여부
    - page: int 조회할 모임 목록 페이지 번호
    - per_page: int 페이지 당 표시할 모임 개수   