### PR TITLE
Feature 21: 사용자 소속 모임 목록 반환 API 추가

### DIFF
--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -1,8 +1,7 @@
 from uuid import UUID
 
 import pendulum
-from sqlalchemy import asc, desc, update
-from sqlalchemy.orm import selectinload
+from sqlalchemy import update
 
 from hobbyroom import database
 from hobbyroom.gathering import domain, query
@@ -11,18 +10,9 @@ from hobbyroom.gathering import domain, query
 class GatheringRepository(database.SQLAlchemyRepository[domain.Gathering]):
     __model_cls__ = database.Gathering
 
-    def list_by_query(self, query: query.ListGatherings) -> list[domain.Gathering]:
-        order_by = (
-            asc(database.Gathering.created_at)
-            if query.ascending
-            else desc(database.Gathering.created_at)
-        )
-        gatherings = (
-            self.session.query(database.Gathering)
-            .order_by(order_by)
-            .offset(query.offset)
-            .limit(query.per_page)
-            .all()
+    def list_by_query(self, query: query.PaginationQuery) -> list[domain.Gathering]:
+        gatherings: list[database.Gathering] = (
+            self.session.execute(query.statement).scalars().all()
         )
         return [
             domain.Gathering(
@@ -38,6 +28,17 @@ class GatheringRepository(database.SQLAlchemyRepository[domain.Gathering]):
     def count_total(self) -> int:
         return self.session.query(database.Gathering).count()
 
+    def count_total_by_personas(self, persona_ids: list[UUID]) -> int:
+        return (
+            self.session.query(database.Gathering)
+            .join(
+                database.Affiliation,
+                database.Gathering.id == database.Affiliation.gathering_id,
+            )
+            .filter(database.Affiliation.persona_id.in_(persona_ids))
+            .count()
+        )
+
 
 class AffiliationRepository(database.SQLAlchemyRepository[domain.Affiliation]):
     __model_cls__ = database.Affiliation
@@ -51,20 +52,9 @@ class AffiliationRepository(database.SQLAlchemyRepository[domain.Affiliation]):
 class PostRepository(database.SQLAlchemyRepository[domain.Post]):
     __model_cls__ = database.Post
 
-    def list_by_query(self, query: query.ListPosts) -> list[domain.SearchedPost]:
-        order_by = (
-            asc(database.Post.created_at)
-            if query.ascending
-            else desc(database.Post.created_at)
-        )
-        posts = (
-            self.session.query(database.Post)
-            .filter_by(gathering_id=query.gathering_id)
-            .order_by(order_by)
-            .offset(query.offset)
-            .limit(query.per_page)
-            .options(selectinload(database.Post.persona))
-            .all()
+    def list_by_query(self, query: query.PaginationQuery) -> list[domain.SearchedPost]:
+        posts: list[database.Post] = (
+            self.session.execute(query.statement).scalars().all()
         )
         return [
             domain.SearchedPost(

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -62,6 +62,10 @@ class ServiceContainer(containers.DeclarativeContainer):
         service.ListGatheringsHandler,
         gathering_unit_of_work=adapter.gathering_unit_of_work,
     )
+    list_user_gatherings_handler = providers.Factory(
+        service.ListUserGatheringsHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -90,6 +90,37 @@ async def list_gatherings(
     return handler.handle(qry)
 
 
+@router.get(
+    "/v1/gatherings/affiliated",
+    response_model=schema.ListedGatherings,
+    status_code=http.HTTPStatus.OK,
+    summary="내 모임 목록 조회",
+    description="현재 사용자가 소속된 모임들의 목록을 반환합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+    ),
+)
+@inject
+async def list_user_gatherings(
+    ascending: bool = False,
+    page: int = 1,
+    per_page: int = 10,
+    user: auth.User = Depends(depends.get_current_user),
+    handler: service.ListUserGatheringsHandler = Depends(
+        Provide[Container.gathering.service.list_user_gatherings_handler]
+    ),
+):
+    qry = query.ListUserGatherings.create(
+        user=user,
+        ascending=ascending,
+        page=page,
+        per_page=per_page,
+    )
+    return handler.handle(qry)
+
+
 @router.post(
     "/v1/gatherings/{gathering_id}/posts",
     status_code=http.HTTPStatus.CREATED,

--- a/hobbyroom/gathering/query.py
+++ b/hobbyroom/gathering/query.py
@@ -1,3 +1,4 @@
+import abc
 from typing import Self
 from uuid import UUID
 
@@ -9,7 +10,7 @@ from sqlalchemy.sql import Select
 from hobbyroom import auth, database
 
 
-class PaginationQuery(BaseModel):
+class PaginationQuery(BaseModel, abc.ABC):
     ascending: bool = False
     page: int = Field(ge=1, default=1)
     per_page: int = Field(le=100, default=10)
@@ -18,6 +19,13 @@ class PaginationQuery(BaseModel):
     def offset(self) -> int:
         return (self.page - 1) * self.per_page
 
+    @property
+    @abc.abstractmethod
+    def statement(self) -> Select:
+        raise NotImplementedError
+
+
+class ListGatherings(PaginationQuery):
     @property
     def statement(self) -> Select:
         order_by = (
@@ -31,9 +39,6 @@ class PaginationQuery(BaseModel):
             .offset(self.offset)
             .limit(self.per_page)
         )
-
-
-class ListGatherings(PaginationQuery): ...
 
 
 class ListUserGatherings(PaginationQuery):

--- a/hobbyroom/gathering/query.py
+++ b/hobbyroom/gathering/query.py
@@ -1,9 +1,15 @@
+from typing import Self
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+from sqlalchemy import asc, desc, select
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql import Select
+
+from hobbyroom import auth, database
 
 
-class ListGatherings(BaseModel):
+class PaginationQuery(BaseModel):
     ascending: bool = False
     page: int = Field(ge=1, default=1)
     per_page: int = Field(le=100, default=10)
@@ -12,16 +18,74 @@ class ListGatherings(BaseModel):
     def offset(self) -> int:
         return (self.page - 1) * self.per_page
 
+    @property
+    def statement(self) -> Select:
+        order_by = (
+            asc(database.Gathering.created_at)
+            if self.ascending
+            else desc(database.Gathering.created_at)
+        )
+        return (
+            select(database.Gathering)
+            .order_by(order_by)
+            .offset(self.offset)
+            .limit(self.per_page)
+        )
 
-class ListPosts(BaseModel):
-    gathering_id: UUID
-    ascending: bool
-    page: int = Field(ge=1)
-    per_page: int = Field(le=100)
+
+class ListGatherings(PaginationQuery): ...
+
+
+class ListUserGatherings(PaginationQuery):
+    persona_ids: list[UUID]
+
+    @classmethod
+    def create(cls, user: auth.User, ascending: bool, page: int, per_page: int) -> Self:
+        return cls(
+            persona_ids=[persona.id for persona in user.personas],
+            ascending=ascending,
+            page=page,
+            per_page=per_page,
+        )
 
     @property
-    def offset(self) -> int:
-        return (self.page - 1) * self.per_page
+    def statement(self) -> Select:
+        order_by = (
+            asc(database.Gathering.created_at)
+            if self.ascending
+            else desc(database.Gathering.created_at)
+        )
+        return (
+            select(database.Gathering)
+            .join(
+                database.Affiliation,
+                database.Gathering.id == database.Affiliation.gathering_id,
+            )
+            .where(database.Affiliation.persona_id.in_(self.persona_ids))
+            .order_by(order_by)
+            .offset(self.offset)
+            .limit(self.per_page)
+        )
+
+
+class ListPosts(PaginationQuery):
+    gathering_id: UUID
+
+    @property
+    def statement(self) -> Select:
+        order_by = (
+            asc(database.Post.created_at)
+            if self.ascending
+            else desc(database.Post.created_at)
+        )
+        return (
+            select(database.Post)
+            .where(database.Post.gathering_id == self.gathering_id)
+            .order_by(order_by)
+            .offset(self.offset)
+            .limit(self.per_page)
+            .options(selectinload(database.Post.persona))
+        )
 
 
 class RetrievePost(BaseModel):

--- a/hobbyroom/gathering/service/query_handler.py
+++ b/hobbyroom/gathering/service/query_handler.py
@@ -41,3 +41,18 @@ class ListGatheringsHandler:
             gatherings = uow.gathering.list_by_query(query)
 
         return schema.ListedGatherings(total=total, gatherings=gatherings)
+
+
+class ListUserGatheringsHandler:
+    def __init__(self, gathering_unit_of_work: adapter.GatheringUnitOfWork):
+        self.gathering_unit_of_work = gathering_unit_of_work
+
+    def handle(self, query: query.ListUserGatherings) -> schema.ListedGatherings:
+        if not query.persona_ids:
+            return schema.ListedGatherings(total=0, gatherings=[])
+
+        with self.gathering_unit_of_work as uow:
+            total = uow.gathering.count_total_by_personas(query.persona_ids)
+            gatherings = uow.gathering.list_by_query(query)
+
+        return schema.ListedGatherings(total=total, gatherings=gatherings)


### PR DESCRIPTION
## 요약
사용자가 속해있는 모임들의 리스트를 반환하는 API를 추가합니다.

## 변경사항
- `GET /v1/gatherings/affiliated` 엔드포인트가 추가됩니다.
- 페이지네이션을 필요로 하는 리스트 쿼리들의 공통 추상 클래스 `PaginationQuery`를 추가합니다.
- 쿼리를 사용하여 레포지토리에서 리스트 조회시, 쿼리 객체에 선언되어 있는 Select 쿼리문을 사용하도록 수정합니다.
- 사용자 페르소나 ID 목록을 기반으로 소속되어 있는 모임 목록을 반환하는 쿼리 및 쿼리 핸들러를 추가합니다.