### PR TITLE
Feature 22: 모임 상세 정보 반환 API 추가

### DIFF
--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -51,9 +51,9 @@ class AffiliationRepository(database.SQLAlchemyRepository[domain.Affiliation]):
     def find_gathering_leader(self, gathering_id: UUID) -> domain.Persona | None:
         result = (
             self.session.query(database.Persona.id, database.Persona.name)
+            .select_from(database.Affiliation)
             .join(
-                database.Affiliation,
-                database.Persona.id == database.Affiliation.persona_id,
+                database.Persona, database.Persona.id == database.Affiliation.persona_id
             )
             .filter(
                 database.Affiliation.gathering_id == gathering_id,

--- a/hobbyroom/gathering/adapter/repository.py
+++ b/hobbyroom/gathering/adapter/repository.py
@@ -48,6 +48,33 @@ class AffiliationRepository(database.SQLAlchemyRepository[domain.Affiliation]):
     ) -> domain.Affiliation | None:
         return self.find_by(persona_id=persona_id, gathering_id=gathering_id)
 
+    def find_gathering_leader(self, gathering_id: UUID) -> domain.Persona | None:
+        result = (
+            self.session.query(database.Persona.id, database.Persona.name)
+            .join(
+                database.Affiliation,
+                database.Persona.id == database.Affiliation.persona_id,
+            )
+            .filter(
+                database.Affiliation.gathering_id == gathering_id,
+                database.Affiliation.is_leader,
+            )
+            .first()
+        )
+        if result:
+            return domain.Persona(
+                id=result.id,
+                name=result.name,
+            )
+        return None
+
+    def count_gathering_members(self, gathering_id: UUID) -> int:
+        return (
+            self.session.query(database.Affiliation)
+            .filter_by(gathering_id=gathering_id)
+            .count()
+        )
+
 
 class PostRepository(database.SQLAlchemyRepository[domain.Post]):
     __model_cls__ = database.Post

--- a/hobbyroom/gathering/dependency.py
+++ b/hobbyroom/gathering/dependency.py
@@ -66,6 +66,10 @@ class ServiceContainer(containers.DeclarativeContainer):
         service.ListUserGatheringsHandler,
         gathering_unit_of_work=adapter.gathering_unit_of_work,
     )
+    retrieve_gathering_handler = providers.Factory(
+        service.RetrieveGatheringHandler,
+        gathering_unit_of_work=adapter.gathering_unit_of_work,
+    )
 
 
 class GatheringContainer(containers.DeclarativeContainer):

--- a/hobbyroom/gathering/domain/vo.py
+++ b/hobbyroom/gathering/domain/vo.py
@@ -11,3 +11,8 @@ class SearchedPost(BaseModel):
     writer: str
     created_at: datetime.datetime
     updated_at: datetime.datetime
+
+
+class Persona(BaseModel):
+    id: UUID
+    name: str

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -91,6 +91,37 @@ async def list_gatherings(
 
 
 @router.get(
+    "/v1/gatherings/affiliated",
+    response_model=schema.ListedGatherings,
+    status_code=http.HTTPStatus.OK,
+    summary="내 모임 목록 조회",
+    description="현재 사용자가 소속된 모임들의 목록을 반환합니다.",
+    tags=[constants.OpenApiTag.GATHERING],
+    responses=exceptions.get_responses(
+        http.HTTPStatus.UNPROCESSABLE_ENTITY,
+        http.HTTPStatus.UNAUTHORIZED,
+    ),
+)
+@inject
+async def list_user_gatherings(
+    ascending: bool = False,
+    page: int = 1,
+    per_page: int = 10,
+    user: auth.User = Depends(depends.get_current_user),
+    handler: service.ListUserGatheringsHandler = Depends(
+        Provide[Container.gathering.service.list_user_gatherings_handler]
+    ),
+):
+    qry = query.ListUserGatherings.create(
+        user=user,
+        ascending=ascending,
+        page=page,
+        per_page=per_page,
+    )
+    return handler.handle(qry)
+
+
+@router.get(
     "/v1/gatherings/{gathering_id}",
     response_model=schema.RetrievedGathering,
     status_code=http.HTTPStatus.OK,

--- a/hobbyroom/gathering/entrypoint.py
+++ b/hobbyroom/gathering/entrypoint.py
@@ -91,32 +91,26 @@ async def list_gatherings(
 
 
 @router.get(
-    "/v1/gatherings/affiliated",
-    response_model=schema.ListedGatherings,
+    "/v1/gatherings/{gathering_id}",
+    response_model=schema.RetrievedGathering,
     status_code=http.HTTPStatus.OK,
-    summary="내 모임 목록 조회",
-    description="현재 사용자가 소속된 모임들의 목록을 반환합니다.",
+    summary="모임 조회",
+    description="모임의 상세 정보를 조회합니다.",
     tags=[constants.OpenApiTag.GATHERING],
     responses=exceptions.get_responses(
         http.HTTPStatus.UNPROCESSABLE_ENTITY,
-        http.HTTPStatus.UNAUTHORIZED,
+        http.HTTPStatus.NOT_FOUND,
     ),
 )
 @inject
-async def list_user_gatherings(
-    ascending: bool = False,
-    page: int = 1,
-    per_page: int = 10,
-    user: auth.User = Depends(depends.get_current_user),
-    handler: service.ListUserGatheringsHandler = Depends(
-        Provide[Container.gathering.service.list_user_gatherings_handler]
+async def retrieve_gathering(
+    gathering_id: UUID,
+    handler: service.RetrieveGatheringHandler = Depends(
+        Provide[Container.gathering.service.retrieve_gathering_handler]
     ),
 ):
-    qry = query.ListUserGatherings.create(
-        user=user,
-        ascending=ascending,
-        page=page,
-        per_page=per_page,
+    qry = query.RetrieveGathering(
+        gathering_id=gathering_id,
     )
     return handler.handle(qry)
 

--- a/hobbyroom/gathering/query.py
+++ b/hobbyroom/gathering/query.py
@@ -93,6 +93,10 @@ class ListPosts(PaginationQuery):
         )
 
 
+class RetrieveGathering(BaseModel):
+    gathering_id: UUID
+
+
 class RetrievePost(BaseModel):
     gathering_id: UUID
     post_id: UUID

--- a/hobbyroom/gathering/schema/response.py
+++ b/hobbyroom/gathering/schema/response.py
@@ -1,3 +1,6 @@
+import datetime
+from uuid import UUID
+
 from pydantic import BaseModel
 
 from hobbyroom.gathering import domain
@@ -11,3 +14,13 @@ class ListedGatherings(BaseModel):
 class ListedPosts(BaseModel):
     total: int
     posts: list[domain.SearchedPost]
+
+
+class RetrievedGathering(BaseModel):
+    id: UUID
+    name: str
+    description: str
+    leader: domain.Persona
+    member_count: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime

--- a/hobbyroom/gathering/service/query_handler.py
+++ b/hobbyroom/gathering/service/query_handler.py
@@ -56,3 +56,26 @@ class ListUserGatheringsHandler:
             gatherings = uow.gathering.list_by_query(query)
 
         return schema.ListedGatherings(total=total, gatherings=gatherings)
+
+
+class RetrieveGatheringHandler:
+    def __init__(self, gathering_unit_of_work: adapter.GatheringUnitOfWork):
+        self.gathering_unit_of_work = gathering_unit_of_work
+
+    def handle(self, query: query.RetrieveGathering) -> schema.RetrievedGathering:
+        with self.gathering_unit_of_work as uow:
+            gathering = uow.gathering.find_by_id(query.gathering_id)
+            if gathering is None:
+                raise exceptions.NotFoundError("존재하지 않는 모임입니다.")
+            leader = uow.affiliation.find_gathering_leader(query.gathering_id)
+            member_count = uow.affiliation.count_gathering_members(query.gathering_id)
+
+        return schema.RetrievedGathering(
+            id=gathering.id,
+            name=gathering.name,
+            description=gathering.description,
+            leader=leader,
+            member_count=member_count,
+            created_at=gathering.created_at,
+            updated_at=gathering.updated_at,
+        )


### PR DESCRIPTION
## 요약
모임장, 모임원 수를 포함한 모임에 대한 상세 정보를 반환하는 API를 추가합니다.

## 변경사항
- `GET /v1/gatherings/{gathering_id}` 엔드포인트가 추가됩니다.
- `RetrieveGathering` 쿼리 및 쿼리 핸들러가 추가됩니다.
- `Persona` 값객체가 gathering 도메인에 추가됩니다.
- 모임장 조회 메소드와 모임원 수 계산 메소드가 `AffiliationRepository`에 추가됩니다.