### PR TITLE
Feature 23: 모임 채팅 기능 구현

### DIFF
--- a/hobbyroom/app/main.py
+++ b/hobbyroom/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse
 
 from hobbyroom import exceptions
 from hobbyroom.auth.entrypoint import router as auth_router
+from hobbyroom.chat.entrypoint import router as chat_router
 from hobbyroom.container import Container
 from hobbyroom.gathering.entrypoint import router as gathering_router
 from hobbyroom.user.entrypoint import router as user_router
@@ -37,6 +38,7 @@ def inject_dependencies(_app: FastAPI) -> None:
 
 def add_routers(_app: FastAPI) -> None:
     _app.include_router(auth_router)
+    _app.include_router(chat_router)
     _app.include_router(user_router)
     _app.include_router(gathering_router)
 

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -11,9 +11,9 @@ from hobbyroom.chat import enums, schema
 
 
 class ConnectionManager:
-    def __init__(self):
+    def __init__(self, clock: Callable[..., pendulum.DateTime]):
         self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
-        self.clock: Callable[..., pendulum.DateTime]
+        self.clock = clock
 
     async def connect(self, websocket: WebSocket, persona: auth.Persona) -> None:
         await websocket.accept()

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -1,0 +1,72 @@
+from collections import defaultdict
+from collections.abc import Callable
+from uuid import UUID
+
+import pendulum
+from fastapi import WebSocket, WebSocketDisconnect, WebSocketException, status
+
+from hobbyroom import auth
+from hobbyroom.chat import enums, schema
+
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
+        self.clock: Callable[..., pendulum.DateTime]
+
+    async def connect(self, websocket: WebSocket, persona: auth.Persona):
+        await websocket.accept()
+        self.active_connections[persona.gathering_id].append(websocket)
+
+        join_message = schema.UserMessage(
+            content=f"{persona.name}님이 채팅방에 입장했습니다.",
+            message_type=enums.MessageType.JOIN,
+            persona_id=persona.id,
+            persona_name=persona.name,
+            timestamp=self.clock(),
+        )
+        await self.broadcast_to_gathering(
+            gathering_id=persona.gathering_id,
+            message=join_message,
+        )
+
+    async def disconnect(self, websocket: WebSocket, persona: auth.Persona):
+        self.active_connections[persona.gathering_id].remove(websocket)
+        if not self.active_connections[persona.gathering_id]:
+            self.refresh_connections()
+            return
+
+        leave_message = schema.UserMessage(
+            content=f"{persona.name}님이 채팅방을 나갔습니다.",
+            message_type=enums.MessageType.LEAVE,
+            persona_id=persona.id,
+            persona_name=persona.name,
+            timestamp=self.clock(),
+        )
+        await self.broadcast_to_gathering(
+            gathering_id=persona.gathering_id,
+            message=leave_message,
+        )
+
+    async def broadcast_to_gathering(
+        self, gathering_id: UUID, message: schema.OutgoingMessage
+    ):
+        connections: list[WebSocket] = self.active_connections.get(gathering_id, [])
+        if not connections:
+            raise WebSocketException(
+                code=status.WS_1008_POLICY_VIOLATION,
+                reason="해당 모임에 연결된 사용자가 없습니다.",
+            )
+        message_data = message.model_dump_json()
+        for websocket in connections:
+            try:
+                await websocket.send_text(message_data)
+            except WebSocketDisconnect:
+                continue
+
+    def refresh_connections(self):
+        self.active_connections = {
+            gathering_id: connections
+            for gathering_id, connections in self.active_connections.items()
+            if connections
+        }

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict
 from collections.abc import Callable
 from uuid import UUID
@@ -14,7 +15,7 @@ class ConnectionManager:
         self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
         self.clock: Callable[..., pendulum.DateTime]
 
-    async def connect(self, websocket: WebSocket, persona: auth.Persona):
+    async def connect(self, websocket: WebSocket, persona: auth.Persona) -> None:
         await websocket.accept()
         self.active_connections[persona.gathering_id].append(websocket)
 
@@ -30,7 +31,7 @@ class ConnectionManager:
             message=join_message,
         )
 
-    async def disconnect(self, websocket: WebSocket, persona: auth.Persona):
+    async def disconnect(self, websocket: WebSocket, persona: auth.Persona) -> None:
         self.active_connections[persona.gathering_id].remove(websocket)
         if not self.active_connections[persona.gathering_id]:
             self.refresh_connections()
@@ -48,9 +49,36 @@ class ConnectionManager:
             message=leave_message,
         )
 
+    async def receive_message(
+        self, websocket: WebSocket, persona: auth.Persona
+    ) -> None:
+        data = await websocket.receive_text()
+        try:
+            message_data = json.loads(data)
+            incoming_message = schema.IncomingMessage.model_validate(message_data)
+        except json.JSONDecodeError:
+            error_message = schema.SystemMessage(
+                content="잘못된 메시지 형식입니다.",
+                timestamp=self.clock(),
+            )
+            await websocket.send_text(error_message.model_dump_json())
+            return
+
+        outgoing_message = schema.UserMessage(
+            content=incoming_message.content,
+            message_type=incoming_message.message_type,
+            persona_id=persona.id,
+            persona_name=persona.name,
+            timestamp=self.clock(),
+        )
+        await self.broadcast_to_gathering(
+            gathering_id=persona.gathering_id,
+            message=outgoing_message,
+        )
+
     async def broadcast_to_gathering(
         self, gathering_id: UUID, message: schema.OutgoingMessage
-    ):
+    ) -> None:
         connections: list[WebSocket] = self.active_connections.get(gathering_id, [])
         if not connections:
             raise WebSocketException(
@@ -64,7 +92,7 @@ class ConnectionManager:
             except WebSocketDisconnect:
                 continue
 
-    def refresh_connections(self):
+    def refresh_connections(self) -> None:
         self.active_connections = {
             gathering_id: connections
             for gathering_id, connections in self.active_connections.items()

--- a/hobbyroom/chat/dependency.py
+++ b/hobbyroom/chat/dependency.py
@@ -1,0 +1,21 @@
+from dependency_injector import containers, providers
+
+from hobbyroom.chat import connection_manager
+
+
+class ServiceContainer(containers.DeclarativeContainer):
+    clock = providers.Dependency()
+
+    connection_manager = providers.Singleton(
+        connection_manager.ConnectionManager,
+        clock=clock,
+    )
+
+
+class ChatContainer(containers.DeclarativeContainer):
+    clock = providers.Dependency()
+
+    service = providers.Container(
+        ServiceContainer,
+        clock=clock,
+    )

--- a/hobbyroom/chat/entrypoint.py
+++ b/hobbyroom/chat/entrypoint.py
@@ -1,0 +1,26 @@
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends, WebSocket
+from fastapi.routing import APIRouter
+
+from hobbyroom import auth, depends
+from hobbyroom.chat import connection_manager
+from hobbyroom.container import Container
+
+router = APIRouter()
+
+
+@router.websocket("/v1/chat/{gathering_id}")
+@inject
+async def chat_endpoint(
+    websocket: WebSocket,
+    persona: auth.Persona = Depends(depends.get_current_persona_ws),
+    connection_manager: connection_manager.ConnectionManager = Depends(
+        Provide[Container.chat.service.connection_manager]
+    ),
+):
+    try:
+        await connection_manager.connect(websocket, persona)
+        while True:
+            await connection_manager.receive_message(websocket, persona)
+    except Exception:
+        await connection_manager.disconnect(websocket, persona)

--- a/hobbyroom/chat/enums.py
+++ b/hobbyroom/chat/enums.py
@@ -1,7 +1,7 @@
 import enum
 
 
-class MessageType(str, enum.Enum):
+class MessageType(enum.StrEnum):
     TEXT = enum.auto()
     JOIN = enum.auto()
     LEAVE = enum.auto()

--- a/hobbyroom/chat/enums.py
+++ b/hobbyroom/chat/enums.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class MessageType(str, enum.Enum):
+    TEXT = enum.auto()
+    JOIN = enum.auto()
+    LEAVE = enum.auto()
+    SYSTEM = enum.auto()

--- a/hobbyroom/chat/schema.py
+++ b/hobbyroom/chat/schema.py
@@ -1,0 +1,26 @@
+import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from hobbyroom.chat import enums
+
+
+class IncomingMessage(BaseModel):
+    content: str
+    message_type: enums.MessageType = enums.MessageType.TEXT
+
+
+class OutgoingMessage(BaseModel):
+    content: str
+    message_type: enums.MessageType
+    timestamp: datetime.datetime
+
+
+class UserMessage(OutgoingMessage):
+    persona_id: UUID
+    persona_name: str
+
+
+class SystemMessage(OutgoingMessage):
+    message_type: enums.MessageType = enums.MessageType.SYSTEM

--- a/hobbyroom/container.py
+++ b/hobbyroom/container.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from uuid6 import uuid7
 
 from hobbyroom.auth.dependency import AuthContainer
+from hobbyroom.chat.dependency import ChatContainer
 from hobbyroom.database.connection import postgres_db
 from hobbyroom.gathering.dependency import GatheringContainer
 from hobbyroom.user.dependency import UserContainer
@@ -14,6 +15,7 @@ class Container(containers.DeclarativeContainer):
         modules=[
             ".depends",
             ".auth.entrypoint",
+            ".chat.entrypoint",
             ".gathering.entrypoint",
             ".user.entrypoint",
         ]
@@ -31,6 +33,10 @@ class Container(containers.DeclarativeContainer):
         AuthContainer,
         session_factory=db_session_factory,
         id_generator=id_generator,
+        clock=clock,
+    )
+    chat = providers.Container(
+        ChatContainer,
         clock=clock,
     )
     gathering = providers.Container(

--- a/hobbyroom/depends.py
+++ b/hobbyroom/depends.py
@@ -70,8 +70,10 @@ async def get_current_persona_ws(
     websocket: WebSocket,
 ) -> auth.Persona:
     token = websocket.query_params.get("token")
-    if not token:
-        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
-    return get_current_persona_core(
-        token=token, gathering_id=websocket.path_params.get("gathering_id")
-    )
+    gathering_id = websocket.path_params.get("gathering_id")
+    if not (token and gathering_id):
+        raise WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION,
+            reason="연결에 필요한 정보가 없습니다.",
+        )
+    return get_current_persona_core(token=token, gathering_id=UUID(gathering_id))

--- a/hobbyroom/depends.py
+++ b/hobbyroom/depends.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import Depends
+from fastapi import Depends, WebSocket, WebSocketException, status
 
 from hobbyroom import auth, exceptions
 from hobbyroom.container import Container
@@ -27,9 +27,9 @@ def get_current_user(
 
 
 @inject
-def get_current_persona(
+def get_current_persona_core(
+    token: str,
     gathering_id: UUID | None = None,
-    token: str = Depends(auth.persona_oauth2_schema),
     jwt_handler: auth.JWTHandler = Depends(Provide[Container.auth.service.jwt_handler]),
     auth_unit_of_work: auth.AuthUnitOfWork = Depends(
         Provide[Container.auth.adapter.auth_unit_of_work]
@@ -55,3 +55,23 @@ def get_current_persona(
             current_gathering_id=gathering_id,
         )
     return persona
+
+
+@inject
+def get_current_persona(
+    gathering_id: UUID | None = None,
+    token: str = Depends(auth.persona_oauth2_schema),
+) -> auth.Persona:
+    return get_current_persona_core(token=token, gathering_id=gathering_id)
+
+
+@inject
+async def get_current_persona_ws(
+    websocket: WebSocket,
+) -> auth.Persona:
+    token = websocket.query_params.get("token")
+    if not token:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+    return get_current_persona_core(
+        token=token, gathering_id=websocket.path_params.get("gathering_id")
+    )

--- a/hobbyroom/depends.py
+++ b/hobbyroom/depends.py
@@ -57,7 +57,6 @@ def get_current_persona_core(
     return persona
 
 
-@inject
 def get_current_persona(
     gathering_id: UUID | None = None,
     token: str = Depends(auth.persona_oauth2_schema),
@@ -65,7 +64,6 @@ def get_current_persona(
     return get_current_persona_core(token=token, gathering_id=gathering_id)
 
 
-@inject
 async def get_current_persona_ws(
     websocket: WebSocket,
 ) -> auth.Persona:

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,5 +10,11 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
     }
 }


### PR DESCRIPTION
## 요약
웹소켓을 사용하여 각 모임 별로 모임원 간 채팅을 할 수 있는 API를 구현합니다.

## 변경사항
- 채팅을 위한 chat 도메인이 추가됩니다.
- `/v1/chat/{gathering_id}` 웹소켓 엔드포인트가 추가됩니다.
  - 쿼리 파라미터 `token`으로 인증 토큰값을 전달받습니다.
- 웹소켓을 통한 메시지 송수신용 스키마를 정의합니다.
- 웹소켓 커넥션 매니저를 추가합니다. 

## TODO
- 사용자 연결 정보 관리 방식 개선
- 연결 유지 및 메시지 수신 방식 개선
- 채팅 내용 저장 및 반환 기능 추가
- 디버깅을 위한 로깅 개선