### PR TITLE
Bugfix: chat 도메인 내 순환참조 해결

### DIFF
--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -6,8 +6,7 @@ from uuid import UUID
 import pendulum
 from fastapi import WebSocket, WebSocketDisconnect, WebSocketException, status
 
-from hobbyroom import auth
-from hobbyroom.chat import enums, schema
+from hobbyroom.chat import domain, enums, schema
 
 
 class ConnectionManager:
@@ -15,42 +14,46 @@ class ConnectionManager:
         self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
         self.clock = clock
 
-    async def connect(self, websocket: WebSocket, persona: auth.Persona) -> None:
+    async def connect(
+        self, websocket: WebSocket, connection_info: domain.ConnectionInfo
+    ) -> None:
         await websocket.accept()
-        self.active_connections[persona.gathering_id].append(websocket)
+        self.active_connections[connection_info.gathering_id].append(websocket)
 
         join_message = schema.UserMessage(
-            content=f"{persona.name}님이 채팅방에 입장했습니다.",
+            content=f"{connection_info.persona_name}님이 채팅방에 입장했습니다.",
             message_type=enums.MessageType.JOIN,
-            persona_id=persona.id,
-            persona_name=persona.name,
+            persona_id=connection_info.persona_id,
+            persona_name=connection_info.persona_name,
             timestamp=self.clock(),
         )
         await self.broadcast_to_gathering(
-            gathering_id=persona.gathering_id,
+            gathering_id=connection_info.gathering_id,
             message=join_message,
         )
 
-    async def disconnect(self, websocket: WebSocket, persona: auth.Persona) -> None:
-        self.active_connections[persona.gathering_id].remove(websocket)
-        if not self.active_connections[persona.gathering_id]:
+    async def disconnect(
+        self, websocket: WebSocket, connection_info: domain.ConnectionInfo
+    ) -> None:
+        self.active_connections[connection_info.gathering_id].remove(websocket)
+        if not self.active_connections[connection_info.gathering_id]:
             self.refresh_connections()
             return
 
         leave_message = schema.UserMessage(
-            content=f"{persona.name}님이 채팅방을 나갔습니다.",
+            content=f"{connection_info.persona_name}님이 채팅방을 나갔습니다.",
             message_type=enums.MessageType.LEAVE,
-            persona_id=persona.id,
-            persona_name=persona.name,
+            persona_id=connection_info.persona_id,
+            persona_name=connection_info.persona_name,
             timestamp=self.clock(),
         )
         await self.broadcast_to_gathering(
-            gathering_id=persona.gathering_id,
+            gathering_id=connection_info.gathering_id,
             message=leave_message,
         )
 
     async def receive_message(
-        self, websocket: WebSocket, persona: auth.Persona
+        self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         data = await websocket.receive_text()
         try:
@@ -67,12 +70,12 @@ class ConnectionManager:
         outgoing_message = schema.UserMessage(
             content=incoming_message.content,
             message_type=incoming_message.message_type,
-            persona_id=persona.id,
-            persona_name=persona.name,
+            persona_id=connection_info.persona_id,
+            persona_name=connection_info.persona_name,
             timestamp=self.clock(),
         )
         await self.broadcast_to_gathering(
-            gathering_id=persona.gathering_id,
+            gathering_id=connection_info.gathering_id,
             message=outgoing_message,
         )
 

--- a/hobbyroom/chat/domain/__init__.py
+++ b/hobbyroom/chat/domain/__init__.py
@@ -1,0 +1,1 @@
+from .vo import *  # noqa: F401, F403

--- a/hobbyroom/chat/domain/vo.py
+++ b/hobbyroom/chat/domain/vo.py
@@ -1,0 +1,9 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ConnectionInfo(BaseModel):
+    persona_id: UUID
+    persona_name: str
+    gathering_id: UUID

--- a/hobbyroom/chat/entrypoint.py
+++ b/hobbyroom/chat/entrypoint.py
@@ -3,7 +3,7 @@ from fastapi import Depends, WebSocket
 from fastapi.routing import APIRouter
 
 from hobbyroom import auth, depends
-from hobbyroom.chat import connection_manager
+from hobbyroom.chat import connection_manager, domain
 from hobbyroom.container import Container
 
 router = APIRouter()
@@ -18,9 +18,14 @@ async def chat_endpoint(
         Provide[Container.chat.service.connection_manager]
     ),
 ):
+    connection_info = domain.ConnectionInfo(
+        persona_id=persona.id,
+        persona_name=persona.name,
+        gathering_id=persona.gathering_id,
+    )
     try:
-        await connection_manager.connect(websocket, persona)
+        await connection_manager.connect(websocket, connection_info)
         while True:
-            await connection_manager.receive_message(websocket, persona)
+            await connection_manager.receive_message(websocket, connection_info)
     except Exception:
-        await connection_manager.disconnect(websocket, persona)
+        await connection_manager.disconnect(websocket, connection_info)


### PR DESCRIPTION
## 요약
chat 도메인 내에서 auth 도메인 객체를 참조하며 발생하는 순환참조 오류를 수정합니다.

## 변경사항
- chat 도메인 내에 `ConnectionInfo` 값객체를 정의합니다.
- chat 도메인 내 `auth.Persona` 객체 의존을 제거합니다.