### PR TITLE
Feature 24: 사용자 연결 정보 관리 방식 수정

### DIFF
--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -11,26 +11,33 @@ from hobbyroom.chat import domain, enums, schema
 
 class ConnectionManager:
     def __init__(self, clock: Callable[..., pendulum.DateTime]):
-        self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
+        self.active_connections: dict[UUID, dict[UUID, list[WebSocket]]] = defaultdict(
+            dict
+        )
         self.clock = clock
 
     async def connect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         await websocket.accept()
-        self.active_connections[connection_info.gathering_id].append(websocket)
+        gathering_connections = self.active_connections[connection_info.gathering_id]
+        persona_connections = gathering_connections.setdefault(
+            connection_info.persona_id, []
+        )
+        persona_connections.append(websocket)
 
-        join_message = schema.UserMessage(
-            content=f"{connection_info.persona_name}님이 채팅방에 입장했습니다.",
-            message_type=enums.MessageType.JOIN,
-            persona_id=connection_info.persona_id,
-            persona_name=connection_info.persona_name,
-            timestamp=self.clock(),
-        )
-        await self.broadcast_to_gathering(
-            gathering_id=connection_info.gathering_id,
-            message=join_message,
-        )
+        if len(persona_connections) <= 1:
+            join_message = schema.UserMessage(
+                content=f"{connection_info.persona_name}님이 채팅방에 입장했습니다.",
+                message_type=enums.MessageType.JOIN,
+                persona_id=connection_info.persona_id,
+                persona_name=connection_info.persona_name,
+                timestamp=self.clock(),
+            )
+            await self.broadcast_to_gathering(
+                gathering_id=connection_info.gathering_id,
+                message=join_message,
+            )
 
     async def disconnect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -55,10 +55,9 @@ class ConnectionManager:
     async def receive_message(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
-        data = await websocket.receive_text()
         try:
-            message_data = json.loads(data)
-            incoming_message = schema.IncomingMessage.model_validate(message_data)
+            message_data = await websocket.receive_json()
+            incoming_message = schema.IncomingMessage.model_validate_json(message_data)
         except json.JSONDecodeError:
             error_message = schema.SystemMessage(
                 content="잘못된 메시지 형식입니다.",

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -114,11 +114,13 @@ class ConnectionManager:
                 continue
 
     def refresh_connections(self) -> None:
-        self.active_connections = {
-            gathering_id: connection
-            for gathering_id, connection in self.active_connections.items()
-            if connection.has_connections
-        }
+        active_connections = {}
+        for gathering_id, gathering_connection in self.active_connections.items():
+            gathering_connection.refresh_persona_connections()
+            if gathering_connection.has_connections:
+                active_connections[gathering_id] = gathering_connection
+
+        self.active_connections = active_connections
         logger.info(f"Refreshed connections: {self.active_connections}")
 
     def retrieve_gathering_connection(

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -1,33 +1,36 @@
-import itertools
 import json
-from collections import defaultdict
 from collections.abc import Callable
 from uuid import UUID
 
 import pendulum
-from fastapi import WebSocket, WebSocketDisconnect, WebSocketException, status
+import pydantic
+from fastapi import WebSocket, WebSocketDisconnect
 
+from hobbyroom import exceptions
 from hobbyroom.chat import domain, enums, schema
+from hobbyroom.logging import get_logger
+
+logger = get_logger()
 
 
 class ConnectionManager:
     def __init__(self, clock: Callable[..., pendulum.DateTime]):
-        self.active_connections: dict[UUID, dict[UUID, list[WebSocket]]] = defaultdict(
-            dict
-        )
+        self.active_connections: dict[UUID, domain.GatheringConnection] = dict()
         self.clock = clock
 
     async def connect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         await websocket.accept()
-        gathering_connections = self.active_connections[connection_info.gathering_id]
-        persona_connections = gathering_connections.setdefault(
-            connection_info.persona_id, []
+        gathering_connections = self.active_connections.setdefault(
+            connection_info.gathering_id,
+            domain.GatheringConnection(gathering_id=connection_info.gathering_id),
         )
-        persona_connections.append(websocket)
-
-        if len(persona_connections) <= 1:
+        persona_connection = gathering_connections.upsert_persona_connection(
+            connection_info=connection_info, websocket=websocket
+        )
+        logger.info(f"Connection Added: {connection_info}")
+        if persona_connection.has_single_connection:
             join_message = schema.UserMessage(
                 content=f"{connection_info.persona_name}님이 채팅방에 입장했습니다.",
                 message_type=enums.MessageType.JOIN,
@@ -43,30 +46,39 @@ class ConnectionManager:
     async def disconnect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
-        self.active_connections[connection_info.gathering_id].remove(websocket)
-        if not self.active_connections[connection_info.gathering_id]:
-            self.refresh_connections()
+        try:
+            persona_connection = self.retrieve_persona_connection(
+                gathering_id=connection_info.gathering_id,
+                persona_id=connection_info.persona_id,
+            )
+        except exceptions.DomainValidationError:
+            logger.warning(
+                f"Persona connection not found during disconnect: {connection_info}"
+            )
             return
 
-        leave_message = schema.UserMessage(
-            content=f"{connection_info.persona_name}님이 채팅방을 나갔습니다.",
-            message_type=enums.MessageType.LEAVE,
-            persona_id=connection_info.persona_id,
-            persona_name=connection_info.persona_name,
-            timestamp=self.clock(),
-        )
-        await self.broadcast_to_gathering(
-            gathering_id=connection_info.gathering_id,
-            message=leave_message,
-        )
+        persona_connection.remove_connection(websocket)
+        if not persona_connection.connections:
+            leave_message = schema.UserMessage(
+                content=f"{connection_info.persona_name}님이 채팅방을 나갔습니다.",
+                message_type=enums.MessageType.LEAVE,
+                persona_id=connection_info.persona_id,
+                persona_name=connection_info.persona_name,
+                timestamp=self.clock(),
+            )
+            await self.broadcast_to_gathering(
+                gathering_id=connection_info.gathering_id,
+                message=leave_message,
+            )
+        logger.info(f"Connection Removed: {connection_info}")
 
     async def receive_message(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         try:
             message_data = await websocket.receive_json()
-            incoming_message = schema.IncomingMessage.model_validate_json(message_data)
-        except json.JSONDecodeError:
+            incoming_message = schema.IncomingMessage.model_validate(message_data)
+        except (json.JSONDecodeError, pydantic.ValidationError):
             error_message = schema.SystemMessage(
                 content="잘못된 메시지 형식입니다.",
                 timestamp=self.clock(),
@@ -89,25 +101,41 @@ class ConnectionManager:
     async def broadcast_to_gathering(
         self, gathering_id: UUID, message: schema.OutgoingMessage
     ) -> None:
-        gathering_connections = self.active_connections.get(gathering_id, {})
-        if not gathering_connections.items():
-            raise WebSocketException(
-                code=status.WS_1008_POLICY_VIOLATION,
-                reason="해당 모임에 연결된 사용자가 없습니다.",
-            )
+        gathering_connection = self.retrieve_gathering_connection(gathering_id)
         message_data = message.model_dump_json()
-        connections = list(
-            itertools.chain.from_iterable(gathering_connections.values())
-        )
-        for websocket in connections:
+        logger.info(f"Broadcasting message: {message_data}")
+        for websocket in gathering_connection.active_websockets:
             try:
                 await websocket.send_text(message_data)
             except WebSocketDisconnect:
+                logger.warning(
+                    f"WebSocket disconnected during broadcast: {gathering_connection}"
+                )
                 continue
 
     def refresh_connections(self) -> None:
         self.active_connections = {
-            gathering_id: connections
-            for gathering_id, connections in self.active_connections.items()
-            if connections
+            gathering_id: connection
+            for gathering_id, connection in self.active_connections.items()
+            if connection.has_connections
         }
+        logger.info(f"Refreshed connections: {self.active_connections}")
+
+    def retrieve_gathering_connection(
+        self, gathering_id: UUID
+    ) -> domain.GatheringConnection:
+        connection = self.active_connections.get(gathering_id)
+        if connection is None:
+            raise exceptions.DomainValidationError("모임 연결 정보를 찾을 수 없습니다.")
+        return connection
+
+    def retrieve_persona_connection(
+        self, gathering_id: UUID, persona_id: UUID
+    ) -> domain.PersonaConnection:
+        gathering_connection = self.retrieve_gathering_connection(gathering_id)
+        persona_connection = gathering_connection.find_persona_connection(persona_id)
+        if persona_connection is None:
+            raise exceptions.DomainValidationError(
+                "페르소나 연결 정보를 찾을 수 없습니다."
+            )
+        return persona_connection

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 from collections import defaultdict
 from collections.abc import Callable
@@ -88,13 +89,16 @@ class ConnectionManager:
     async def broadcast_to_gathering(
         self, gathering_id: UUID, message: schema.OutgoingMessage
     ) -> None:
-        connections: list[WebSocket] = self.active_connections.get(gathering_id, [])
-        if not connections:
+        gathering_connections = self.active_connections.get(gathering_id, {})
+        if not gathering_connections.items():
             raise WebSocketException(
                 code=status.WS_1008_POLICY_VIOLATION,
                 reason="해당 모임에 연결된 사용자가 없습니다.",
             )
         message_data = message.model_dump_json()
+        connections = list(
+            itertools.chain.from_iterable(gathering_connections.values())
+        )
         for websocket in connections:
             try:
                 await websocket.send_text(message_data)

--- a/hobbyroom/chat/domain/vo.py
+++ b/hobbyroom/chat/domain/vo.py
@@ -46,10 +46,9 @@ class GatheringConnection(BaseModel):
 
     @property
     def has_connections(self) -> bool:
-        self.refresh_connections()
         return bool(self.persona_connections)
 
-    def refresh_connections(self) -> None:
+    def refresh_persona_connections(self) -> None:
         self.persona_connections = [
             pc for pc in self.persona_connections if pc.connections
         ]

--- a/hobbyroom/chat/domain/vo.py
+++ b/hobbyroom/chat/domain/vo.py
@@ -1,9 +1,71 @@
+from typing import Self
 from uuid import UUID
 
-from pydantic import BaseModel
+from fastapi import WebSocket
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ConnectionInfo(BaseModel):
     persona_id: UUID
     persona_name: str
     gathering_id: UUID
+
+
+class PersonaConnection(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    persona_id: UUID
+    persona_name: str
+    connections: set[WebSocket]
+
+    @classmethod
+    def create(cls, connection_info: ConnectionInfo, websocket: WebSocket) -> Self:
+        return cls(
+            persona_id=connection_info.persona_id,
+            persona_name=connection_info.persona_name,
+            connections={websocket},
+        )
+
+    @property
+    def has_single_connection(self) -> bool:
+        return len(self.connections) == 1
+
+    def remove_connection(self, websocket: WebSocket) -> None:
+        self.connections.remove(websocket)
+
+
+class GatheringConnection(BaseModel):
+    gathering_id: UUID
+    persona_connections: list[PersonaConnection] = Field(default_factory=list)
+
+    @property
+    def active_websockets(self) -> set[WebSocket]:
+        return {
+            websocket for pc in self.persona_connections for websocket in pc.connections
+        }
+
+    @property
+    def has_connections(self) -> bool:
+        self.refresh_connections()
+        return bool(self.persona_connections)
+
+    def refresh_connections(self) -> None:
+        self.persona_connections = [
+            pc for pc in self.persona_connections if pc.connections
+        ]
+
+    def upsert_persona_connection(
+        self, connection_info: ConnectionInfo, websocket: WebSocket
+    ) -> PersonaConnection:
+        persona_connection = self.find_persona_connection(connection_info.persona_id)
+        if persona_connection is None:
+            persona_connection = PersonaConnection.create(connection_info, websocket)
+            self.persona_connections.append(persona_connection)
+        else:
+            persona_connection.connections.add(websocket)
+        return persona_connection
+
+    def find_persona_connection(self, persona_id: UUID) -> PersonaConnection | None:
+        return next(
+            (pc for pc in self.persona_connections if pc.persona_id == persona_id), None
+        )

--- a/hobbyroom/chat/entrypoint.py
+++ b/hobbyroom/chat/entrypoint.py
@@ -5,8 +5,10 @@ from fastapi.routing import APIRouter
 from hobbyroom import auth, depends
 from hobbyroom.chat import connection_manager, domain
 from hobbyroom.container import Container
+from hobbyroom.logging import get_logger
 
 router = APIRouter()
+logger = get_logger()
 
 
 @router.websocket("/v1/chat/{gathering_id}")
@@ -29,3 +31,5 @@ async def chat_endpoint(
             await connection_manager.receive_message(websocket, connection_info)
     except Exception:
         await connection_manager.disconnect(websocket, connection_info)
+    finally:
+        connection_manager.refresh_connections()

--- a/hobbyroom/logging.py
+++ b/hobbyroom/logging.py
@@ -9,10 +9,17 @@ if TYPE_CHECKING:
     from loguru import Logger
 
 
+logger.remove()
+
 logger.add(
-    sys.stdout,
+    sys.stderr,
     level="INFO",
-    format="{level} | {time} | {message}",
+    format=(
+        "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | "
+        "{name}:{function}:{line} | {message}"
+    ),
+    enqueue=True,
+    colorize=True,
 )
 
 

--- a/hobbyroom/logging.py
+++ b/hobbyroom/logging.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from loguru import Logger
+
+
+logger.add(
+    sys.stdout,
+    level="INFO",
+    format="{level} | {time} | {message}",
+)
+
+
+def get_logger() -> Logger:
+    return logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "dependency-injector>=4.48.1",
     "email-validator>=2.2.0",
     "fastapi[standard]>=0.115.14,<0.116.0",
+    "loguru>=0.7.3",
     "pendulum>=3.1.0",
     "psycopg2-binary>=2.9.10",
     "pydantic>=2.11.7,<3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,7 @@ dependencies = [
     { name = "dependency-injector" },
     { name = "email-validator" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "loguru" },
     { name = "pendulum" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -291,6 +292,7 @@ requires-dist = [
     { name = "dependency-injector", specifier = ">=4.48.1" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.14,<0.116.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "pendulum", specifier = ">=3.1.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
@@ -387,6 +389,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -947,4 +962,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
## 요약
웹소켓 연결 관리 동작을 개선합니다.

## 변경사항
- `loguru` 패키지를 추가합니다.
- `loguru`를 사용한 로깅 설정을 정의합니다.
- 모임 별 페르소나에 의한 채팅 연결이 다중으로 이루어지더라도 관리가 이루어질 수 있도록 연결 정보 값객체를 정의합니다.
- `ConnectionManager`의 `active_connections` 속성 타입을 변경하고 연결, 연결해제, 관리 시 동작을 수정합니다.

## TODO
- 사용자 복수 연결 횟수 제한 구현
- 인메모리 대신 redis를 사용한 연결 정보 관리 적용
- 채팅 내역 기록 구현 및 불필요한 로그 제거