### PR TITLE
Feature 25: Redis 기반 연결 정보 관리 적용

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -43,6 +43,7 @@ services:
   redis:
     container_name: hobbyroom_redis
     image: redis:8.2-alpine
+    command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis_data:/data
     ports:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,6 +15,7 @@ services:
     restart: unless-stopped
     depends_on:
       - db
+      - redis
 
   nginx:
     image: nginx:alpine
@@ -38,6 +39,15 @@ services:
       - db:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    
+  redis:
+    container_name: hobbyroom_redis
+    image: redis:8.2-alpine
+    volumes:
+      - redis_data:/data
+    ports:
+      - 6379:6379
 
 volumes:
   db:
+  redis_data:

--- a/hobbyroom/app/main.py
+++ b/hobbyroom/app/main.py
@@ -1,4 +1,5 @@
 import http
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Response
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
@@ -18,6 +19,7 @@ def create_app() -> FastAPI:
         title="Hobbyroom API",
         description="취미모임 프로젝트 API 서버",
         version="0.1.0",
+        lifespan=lifespan,
     )
     inject_dependencies(_app)
     add_routers(_app)
@@ -78,6 +80,16 @@ def add_docs_routes(_app: FastAPI) -> None:
     )
     async def openapi():
         return get_openapi(title=_app.title, version=_app.version, routes=_app.routes)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    connection_manager = app.container.chat.service.connection_manager()
+    await connection_manager.start()
+
+    yield
+
+    await connection_manager.stop()
 
 
 app = create_app()

--- a/hobbyroom/chat/adapter/__init__.py
+++ b/hobbyroom/chat/adapter/__init__.py
@@ -1,0 +1,1 @@
+from .repository import *  # noqa: F401, F403

--- a/hobbyroom/chat/adapter/repository.py
+++ b/hobbyroom/chat/adapter/repository.py
@@ -1,9 +1,14 @@
 from uuid import UUID
 
 from redis.asyncio import Redis
+from redis.asyncio.client import PubSub
+
+from hobbyroom.logging import get_logger
+
+logger = get_logger()
 
 
-class RedisConnectionInfoRepository:
+class RedisConnectionRepository:
     def __init__(self, redis_client: Redis):
         self.redis_client = redis_client
 
@@ -37,3 +42,11 @@ class RedisConnectionInfoRepository:
             self._connection_namespace(gathering_id, persona_id)
         )
         return int(count) if count else 0
+
+    def get_pubsub(self) -> PubSub:
+        return self.redis_client.pubsub()
+
+    async def publish_message(self, gathering_id: UUID, json_message: str) -> None:
+        channel_name = f"chat:gathering:{gathering_id}"
+        await self.redis_client.publish(channel=channel_name, message=json_message)
+        logger.info(f"Published message to {channel_name}: {json_message}")

--- a/hobbyroom/chat/adapter/repository.py
+++ b/hobbyroom/chat/adapter/repository.py
@@ -1,0 +1,25 @@
+from uuid import UUID
+
+from redis.asyncio import Redis
+
+
+class RedisConnectionInfoRepository:
+    def __init__(self, redis_client: Redis):
+        self.redis_client = redis_client
+
+    async def add_connection_info(
+        self,
+        connection_id: UUID,
+        gathering_id: UUID,
+        persona_id: UUID,
+    ) -> None:
+        namespace = f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
+        await self.redis_client.rpush(namespace, connection_id)
+
+    async def count_persona_connections(
+        self,
+        gathering_id: UUID,
+        persona_id: UUID,
+    ) -> int:
+        namespace = f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
+        return await self.redis_client.llen(namespace)

--- a/hobbyroom/chat/adapter/repository.py
+++ b/hobbyroom/chat/adapter/repository.py
@@ -7,18 +7,33 @@ class RedisConnectionInfoRepository:
     def __init__(self, redis_client: Redis):
         self.redis_client = redis_client
 
+    def _connection_namespace(self, gathering_id: UUID, persona_id: UUID) -> str:
+        return f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
+
     async def add_connection_info(
         self,
         gathering_id: UUID,
         persona_id: UUID,
     ) -> None:
-        namespace = f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
-        await self.redis_client.incr(namespace)
+        await self.redis_client.incr(
+            self._connection_namespace(gathering_id, persona_id)
+        )
+
+    async def remove_connection_info(
+        self,
+        gathering_id: UUID,
+        persona_id: UUID,
+    ) -> None:
+        await self.redis_client.decr(
+            self._connection_namespace(gathering_id, persona_id)
+        )
 
     async def retrieve_persona_connection_count(
         self,
         gathering_id: UUID,
         persona_id: UUID,
     ) -> int:
-        namespace = f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
-        return int(await self.redis_client.get(namespace)) or 0
+        count = await self.redis_client.get(
+            self._connection_namespace(gathering_id, persona_id)
+        )
+        return int(count) if count else 0

--- a/hobbyroom/chat/adapter/repository.py
+++ b/hobbyroom/chat/adapter/repository.py
@@ -9,17 +9,16 @@ class RedisConnectionInfoRepository:
 
     async def add_connection_info(
         self,
-        connection_id: UUID,
         gathering_id: UUID,
         persona_id: UUID,
     ) -> None:
         namespace = f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
-        await self.redis_client.rpush(namespace, connection_id)
+        await self.redis_client.incr(namespace)
 
-    async def count_persona_connections(
+    async def retrieve_persona_connection_count(
         self,
         gathering_id: UUID,
         persona_id: UUID,
     ) -> int:
         namespace = f"chat:gathering:{gathering_id}:persona:{persona_id}:connections"
-        return await self.redis_client.llen(namespace)
+        return int(await self.redis_client.get(namespace)) or 0

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -7,7 +7,6 @@ import pendulum
 import pydantic
 from fastapi import WebSocket, WebSocketDisconnect
 
-from hobbyroom import exceptions
 from hobbyroom.chat import adapter, domain, enums, schema
 from hobbyroom.logging import get_logger
 
@@ -132,22 +131,3 @@ class ConnectionManager:
 
         self.active_connections = active_connections
         logger.info(f"Refreshed connections: {self.active_connections}")
-
-    def retrieve_gathering_connection(
-        self, gathering_id: UUID
-    ) -> domain.GatheringConnection:
-        connection = self.active_connections.get(gathering_id)
-        if connection is None:
-            raise exceptions.DomainValidationError("모임 연결 정보를 찾을 수 없습니다.")
-        return connection
-
-    def retrieve_persona_connection(
-        self, gathering_id: UUID, persona_id: UUID
-    ) -> domain.PersonaConnection:
-        gathering_connection = self.retrieve_gathering_connection(gathering_id)
-        persona_connection = gathering_connection.find_persona_connection(persona_id)
-        if persona_connection is None:
-            raise exceptions.DomainValidationError(
-                "페르소나 연결 정보를 찾을 수 없습니다."
-            )
-        return persona_connection

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -150,7 +150,7 @@ class ConnectionManager:
 
         for websocket in connections:
             try:
-                await websocket.send_json(json_message)
+                await websocket.send_text(json_message)
             except Exception as e:
                 logger.error(f"Error sending message to WebSocket: {e}")
                 disconnected_connections.append(websocket)

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -33,8 +33,6 @@ class ConnectionManager:
             persona_id=connection_info.persona_id,
         )
         self.active_connections[connection_info.gathering_id].append(websocket)
-        logger.info(f"Connection Added: {connection_info}")
-
         connection_count = (
             await self.connection_info_repository.retrieve_persona_connection_count(
                 gathering_id=connection_info.gathering_id,
@@ -53,12 +51,13 @@ class ConnectionManager:
                 gathering_id=connection_info.gathering_id,
                 message=join_message,
             )
+        logger.info(f"Connection Added: {connection_info} | Count: {connection_count}")
 
     async def disconnect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         self.active_connections.get(connection_info.gathering_id, []).remove(websocket)
-        self.connection_info_repository.remove_connection_info(
+        await self.connection_info_repository.remove_connection_info(
             gathering_id=connection_info.gathering_id,
             persona_id=connection_info.persona_id,
         )
@@ -80,7 +79,9 @@ class ConnectionManager:
                 gathering_id=connection_info.gathering_id,
                 message=leave_message,
             )
-        logger.info(f"Connection Removed: {connection_info}")
+        logger.info(
+            f"Connection Removed: {connection_info} | Count: {connection_count}"
+        )
 
     async def receive_message(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
@@ -113,11 +114,12 @@ class ConnectionManager:
     ) -> None:
         gathering_connections = self.active_connections.get(gathering_id, [])
         message_data = message.model_dump_json()
-        logger.info(f"Broadcasting message: {message_data}")
-
         for websocket in gathering_connections:
             try:
                 await websocket.send_text(message_data)
             except WebSocketDisconnect:
                 logger.warning("WebSocket disconnected during broadcast")
                 continue
+        logger.info(
+            f"Message broadcasted: {message_data} | Count: {len(gathering_connections)}"
+        )

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -7,30 +7,45 @@ import pydantic
 from fastapi import WebSocket, WebSocketDisconnect
 
 from hobbyroom import exceptions
-from hobbyroom.chat import domain, enums, schema
+from hobbyroom.chat import adapter, domain, enums, schema
 from hobbyroom.logging import get_logger
 
 logger = get_logger()
 
 
 class ConnectionManager:
-    def __init__(self, clock: Callable[..., pendulum.DateTime]):
-        self.active_connections: dict[UUID, domain.GatheringConnection] = dict()
+    def __init__(
+        self,
+        connection_info_repository: adapter.RedisConnectionInfoRepository,
+        clock: Callable[..., pendulum.DateTime],
+        id_generator: Callable[..., UUID],
+    ):
+        self.active_connections: dict[UUID, WebSocket] = dict()
+        self.connection_info_repository = connection_info_repository
         self.clock = clock
+        self.id_generator = id_generator
 
     async def connect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         await websocket.accept()
-        gathering_connections = self.active_connections.setdefault(
-            connection_info.gathering_id,
-            domain.GatheringConnection(gathering_id=connection_info.gathering_id),
+        connection_id = self.id_generator()
+
+        await self.connection_info_repository.add_connection_info(
+            connection_id=connection_id,
+            gathering_id=connection_info.gathering_id,
+            persona_id=connection_info.persona_id,
         )
-        persona_connection = gathering_connections.upsert_persona_connection(
-            connection_info=connection_info, websocket=websocket
+        self.active_connections[connection_id] = websocket
+
+        connection_count = (
+            await self.connection_info_repository.count_persona_connections(
+                gathering_id=connection_info.gathering_id,
+                persona_id=connection_info.persona_id,
+            )
         )
         logger.info(f"Connection Added: {connection_info}")
-        if persona_connection.has_single_connection:
+        if connection_count == 1:
             join_message = schema.UserMessage(
                 content=f"{connection_info.persona_name}님이 채팅방에 입장했습니다.",
                 message_type=enums.MessageType.JOIN,

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -58,19 +58,18 @@ class ConnectionManager:
     async def disconnect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
-        try:
-            persona_connection = self.retrieve_persona_connection(
+        self.active_connections.get(connection_info.gathering_id, []).remove(websocket)
+        self.connection_info_repository.remove_connection_info(
+            gathering_id=connection_info.gathering_id,
+            persona_id=connection_info.persona_id,
+        )
+        connection_count = (
+            await self.connection_info_repository.retrieve_persona_connection_count(
                 gathering_id=connection_info.gathering_id,
                 persona_id=connection_info.persona_id,
             )
-        except exceptions.DomainValidationError:
-            logger.warning(
-                f"Persona connection not found during disconnect: {connection_info}"
-            )
-            return
-
-        persona_connection.remove_connection(websocket)
-        if not persona_connection.connections:
+        )
+        if connection_count < 1:
             leave_message = schema.UserMessage(
                 content=f"{connection_info.persona_name}님이 채팅방을 나갔습니다.",
                 message_type=enums.MessageType.LEAVE,

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from collections import defaultdict
 from collections.abc import Callable
@@ -5,7 +6,7 @@ from uuid import UUID
 
 import pendulum
 import pydantic
-from fastapi import WebSocket, WebSocketDisconnect
+from fastapi import WebSocket
 
 from hobbyroom.chat import adapter, domain, enums, schema
 from hobbyroom.logging import get_logger
@@ -16,25 +17,46 @@ logger = get_logger()
 class ConnectionManager:
     def __init__(
         self,
-        connection_info_repository: adapter.RedisConnectionInfoRepository,
+        connection_repository: adapter.RedisConnectionRepository,
         clock: Callable[..., pendulum.DateTime],
     ):
-        self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
-        self.connection_info_repository = connection_info_repository
+        self.local_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
+        self.connection_repository = connection_repository
         self.clock = clock
+        self.redis_pubsub = None
+        self.listener_task = None
+
+    async def start(self):
+        self.redis_pubsub = self.connection_repository.get_pubsub()
+        self.listener_task = asyncio.create_task(self.listen_to_messages())
+
+    async def stop(self):
+        if self.listener_task:
+            self.listener_task.cancel()
+            try:
+                await self.listener_task
+            except asyncio.CancelledError:
+                pass
+        if self.redis_pubsub:
+            await self.redis_pubsub.close()
 
     async def connect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         await websocket.accept()
-
-        await self.connection_info_repository.add_connection_info(
+        await self.connection_repository.add_connection_info(
             gathering_id=connection_info.gathering_id,
             persona_id=connection_info.persona_id,
         )
-        self.active_connections[connection_info.gathering_id].append(websocket)
+        gathering_connections = self.local_connections[connection_info.gathering_id]
+        if not gathering_connections:
+            await self.redis_pubsub.subscribe(
+                f"chat:gathering:{connection_info.gathering_id}"
+            )
+        gathering_connections.append(websocket)
+
         connection_count = (
-            await self.connection_info_repository.retrieve_persona_connection_count(
+            await self.connection_repository.retrieve_persona_connection_count(
                 gathering_id=connection_info.gathering_id,
                 persona_id=connection_info.persona_id,
             )
@@ -47,41 +69,11 @@ class ConnectionManager:
                 persona_name=connection_info.persona_name,
                 timestamp=self.clock(),
             )
-            await self.broadcast_to_gathering(
+            await self.connection_repository.publish_message(
                 gathering_id=connection_info.gathering_id,
-                message=join_message,
+                json_message=join_message.model_dump_json(),
             )
         logger.info(f"Connection Added: {connection_info} | Count: {connection_count}")
-
-    async def disconnect(
-        self, websocket: WebSocket, connection_info: domain.ConnectionInfo
-    ) -> None:
-        self.active_connections.get(connection_info.gathering_id, []).remove(websocket)
-        await self.connection_info_repository.remove_connection_info(
-            gathering_id=connection_info.gathering_id,
-            persona_id=connection_info.persona_id,
-        )
-        connection_count = (
-            await self.connection_info_repository.retrieve_persona_connection_count(
-                gathering_id=connection_info.gathering_id,
-                persona_id=connection_info.persona_id,
-            )
-        )
-        if connection_count < 1:
-            leave_message = schema.UserMessage(
-                content=f"{connection_info.persona_name}님이 채팅방을 나갔습니다.",
-                message_type=enums.MessageType.LEAVE,
-                persona_id=connection_info.persona_id,
-                persona_name=connection_info.persona_name,
-                timestamp=self.clock(),
-            )
-            await self.broadcast_to_gathering(
-                gathering_id=connection_info.gathering_id,
-                message=leave_message,
-            )
-        logger.info(
-            f"Connection Removed: {connection_info} | Count: {connection_count}"
-        )
 
     async def receive_message(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
@@ -104,22 +96,64 @@ class ConnectionManager:
             persona_name=connection_info.persona_name,
             timestamp=self.clock(),
         )
-        await self.broadcast_to_gathering(
+        await self.connection_repository.publish_message(
             gathering_id=connection_info.gathering_id,
-            message=outgoing_message,
+            json_message=outgoing_message.model_dump_json(),
         )
 
-    async def broadcast_to_gathering(
-        self, gathering_id: UUID, message: schema.OutgoingMessage
+    async def disconnect(
+        self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
-        gathering_connections = self.active_connections.get(gathering_id, [])
-        message_data = message.model_dump_json()
-        for websocket in gathering_connections:
-            try:
-                await websocket.send_text(message_data)
-            except WebSocketDisconnect:
-                logger.warning("WebSocket disconnected during broadcast")
-                continue
-        logger.info(
-            f"Message broadcasted: {message_data} | Count: {len(gathering_connections)}"
+        self.local_connections[connection_info.gathering_id].remove(websocket)
+        await self.connection_repository.remove_connection_info(
+            gathering_id=connection_info.gathering_id,
+            persona_id=connection_info.persona_id,
         )
+        connection_count = (
+            await self.connection_repository.retrieve_persona_connection_count(
+                gathering_id=connection_info.gathering_id,
+                persona_id=connection_info.persona_id,
+            )
+        )
+        if connection_count < 1:
+            leave_message = schema.UserMessage(
+                content=f"{connection_info.persona_name}님이 채팅방을 나갔습니다.",
+                message_type=enums.MessageType.LEAVE,
+                persona_id=connection_info.persona_id,
+                persona_name=connection_info.persona_name,
+                timestamp=self.clock(),
+            )
+            await self.connection_repository.publish_message(
+                gathering_id=connection_info.gathering_id,
+                json_message=leave_message.model_dump_json(),
+            )
+        logger.info(
+            f"Connection Removed: {connection_info} | Count: {connection_count}"
+        )
+        if not self.local_connections[connection_info.gathering_id]:
+            await self.redis_pubsub.unsubscribe(
+                f"chat:gathering:{connection_info.gathering_id}"
+            )
+
+    async def listen_to_messages(self) -> None:
+        try:
+            async for message in self.redis_pubsub.listen():
+                if message["type"] == "message":
+                    gathering_id = UUID(message["channel"].split(":")[-1])
+                    await self.broadcast_message(gathering_id, message["data"])
+        except Exception as e:
+            logger.error(f"Error while listening to messages: {e}")
+
+    async def broadcast_message(self, gathering_id: UUID, json_message: str) -> None:
+        connections = self.local_connections[gathering_id]
+        disconnected_connections = []
+
+        for websocket in connections:
+            try:
+                await websocket.send_json(json_message)
+            except Exception as e:
+                logger.error(f"Error sending message to WebSocket: {e}")
+                disconnected_connections.append(websocket)
+
+        for websocket in disconnected_connections:
+            connections.remove(websocket)

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -113,16 +113,15 @@ class ConnectionManager:
     async def broadcast_to_gathering(
         self, gathering_id: UUID, message: schema.OutgoingMessage
     ) -> None:
-        gathering_connection = self.retrieve_gathering_connection(gathering_id)
+        gathering_connections = self.active_connections.get(gathering_id, [])
         message_data = message.model_dump_json()
         logger.info(f"Broadcasting message: {message_data}")
-        for websocket in gathering_connection.active_websockets:
+
+        for websocket in gathering_connections:
             try:
                 await websocket.send_text(message_data)
             except WebSocketDisconnect:
-                logger.warning(
-                    f"WebSocket disconnected during broadcast: {gathering_connection}"
-                )
+                logger.warning("WebSocket disconnected during broadcast")
                 continue
 
     def refresh_connections(self) -> None:

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from collections.abc import Callable
 from uuid import UUID
 
@@ -18,33 +19,29 @@ class ConnectionManager:
         self,
         connection_info_repository: adapter.RedisConnectionInfoRepository,
         clock: Callable[..., pendulum.DateTime],
-        id_generator: Callable[..., UUID],
     ):
-        self.active_connections: dict[UUID, WebSocket] = dict()
+        self.active_connections: dict[UUID, list[WebSocket]] = defaultdict(list)
         self.connection_info_repository = connection_info_repository
         self.clock = clock
-        self.id_generator = id_generator
 
     async def connect(
         self, websocket: WebSocket, connection_info: domain.ConnectionInfo
     ) -> None:
         await websocket.accept()
-        connection_id = self.id_generator()
 
         await self.connection_info_repository.add_connection_info(
-            connection_id=connection_id,
             gathering_id=connection_info.gathering_id,
             persona_id=connection_info.persona_id,
         )
-        self.active_connections[connection_id] = websocket
+        self.active_connections[connection_info.gathering_id].append(websocket)
+        logger.info(f"Connection Added: {connection_info}")
 
         connection_count = (
-            await self.connection_info_repository.count_persona_connections(
+            await self.connection_info_repository.retrieve_persona_connection_count(
                 gathering_id=connection_info.gathering_id,
                 persona_id=connection_info.persona_id,
             )
         )
-        logger.info(f"Connection Added: {connection_info}")
         if connection_count == 1:
             join_message = schema.UserMessage(
                 content=f"{connection_info.persona_name}님이 채팅방에 입장했습니다.",

--- a/hobbyroom/chat/connection_manager.py
+++ b/hobbyroom/chat/connection_manager.py
@@ -121,13 +121,3 @@ class ConnectionManager:
             except WebSocketDisconnect:
                 logger.warning("WebSocket disconnected during broadcast")
                 continue
-
-    def refresh_connections(self) -> None:
-        active_connections = {}
-        for gathering_id, gathering_connection in self.active_connections.items():
-            gathering_connection.refresh_persona_connections()
-            if gathering_connection.has_connections:
-                active_connections[gathering_id] = gathering_connection
-
-        self.active_connections = active_connections
-        logger.info(f"Refreshed connections: {self.active_connections}")

--- a/hobbyroom/chat/dependency.py
+++ b/hobbyroom/chat/dependency.py
@@ -6,8 +6,8 @@ from hobbyroom.chat import adapter, connection_manager
 class AdapterContainer(containers.DeclarativeContainer):
     redis_client = providers.Dependency()
 
-    redis_connection_info_repository = providers.Factory(
-        adapter.RedisConnectionInfoRepository,
+    redis_connection_repository = providers.Factory(
+        adapter.RedisConnectionRepository,
         redis_client=redis_client,
     )
 
@@ -21,7 +21,7 @@ class ServiceContainer(containers.DeclarativeContainer):
     connection_manager = providers.Singleton(
         connection_manager.ConnectionManager,
         clock=clock,
-        connection_info_repository=adapter.redis_connection_info_repository,
+        connection_repository=adapter.redis_connection_repository,
     )
 
 

--- a/hobbyroom/chat/dependency.py
+++ b/hobbyroom/chat/dependency.py
@@ -16,20 +16,17 @@ class ServiceContainer(containers.DeclarativeContainer):
     adapter = providers.DependenciesContainer()
 
     clock = providers.Dependency()
-    id_generator = providers.Dependency()
     redis_client = providers.Dependency()
 
     connection_manager = providers.Singleton(
         connection_manager.ConnectionManager,
         clock=clock,
-        id_generator=id_generator,
         connection_info_repository=adapter.redis_connection_info_repository,
     )
 
 
 class ChatContainer(containers.DeclarativeContainer):
     clock = providers.Dependency()
-    id_generator = providers.Dependency()
     redis_client = providers.Dependency()
 
     adapter = providers.Container(
@@ -40,6 +37,5 @@ class ChatContainer(containers.DeclarativeContainer):
         ServiceContainer,
         adapter=adapter,
         clock=clock,
-        id_generator=id_generator,
-        redis=redis_client,
+        redis_client=redis_client,
     )

--- a/hobbyroom/chat/dependency.py
+++ b/hobbyroom/chat/dependency.py
@@ -1,21 +1,45 @@
 from dependency_injector import containers, providers
 
-from hobbyroom.chat import connection_manager
+from hobbyroom.chat import adapter, connection_manager
+
+
+class AdapterContainer(containers.DeclarativeContainer):
+    redis_client = providers.Dependency()
+
+    redis_connection_info_repository = providers.Factory(
+        adapter.RedisConnectionInfoRepository,
+        redis_client=redis_client,
+    )
 
 
 class ServiceContainer(containers.DeclarativeContainer):
+    adapter = providers.DependenciesContainer()
+
     clock = providers.Dependency()
+    id_generator = providers.Dependency()
+    redis_client = providers.Dependency()
 
     connection_manager = providers.Singleton(
         connection_manager.ConnectionManager,
         clock=clock,
+        id_generator=id_generator,
+        connection_info_repository=adapter.redis_connection_info_repository,
     )
 
 
 class ChatContainer(containers.DeclarativeContainer):
     clock = providers.Dependency()
+    id_generator = providers.Dependency()
+    redis_client = providers.Dependency()
 
+    adapter = providers.Container(
+        AdapterContainer,
+        redis_client=redis_client,
+    )
     service = providers.Container(
         ServiceContainer,
+        adapter=adapter,
         clock=clock,
+        id_generator=id_generator,
+        redis=redis_client,
     )

--- a/hobbyroom/chat/domain/vo.py
+++ b/hobbyroom/chat/domain/vo.py
@@ -1,70 +1,9 @@
-from typing import Self
 from uuid import UUID
 
-from fastapi import WebSocket
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel
 
 
 class ConnectionInfo(BaseModel):
     persona_id: UUID
     persona_name: str
     gathering_id: UUID
-
-
-class PersonaConnection(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    persona_id: UUID
-    persona_name: str
-    connections: set[WebSocket]
-
-    @classmethod
-    def create(cls, connection_info: ConnectionInfo, websocket: WebSocket) -> Self:
-        return cls(
-            persona_id=connection_info.persona_id,
-            persona_name=connection_info.persona_name,
-            connections={websocket},
-        )
-
-    @property
-    def has_single_connection(self) -> bool:
-        return len(self.connections) == 1
-
-    def remove_connection(self, websocket: WebSocket) -> None:
-        self.connections.remove(websocket)
-
-
-class GatheringConnection(BaseModel):
-    gathering_id: UUID
-    persona_connections: list[PersonaConnection] = Field(default_factory=list)
-
-    @property
-    def active_websockets(self) -> set[WebSocket]:
-        return {
-            websocket for pc in self.persona_connections for websocket in pc.connections
-        }
-
-    @property
-    def has_connections(self) -> bool:
-        return bool(self.persona_connections)
-
-    def refresh_persona_connections(self) -> None:
-        self.persona_connections = [
-            pc for pc in self.persona_connections if pc.connections
-        ]
-
-    def upsert_persona_connection(
-        self, connection_info: ConnectionInfo, websocket: WebSocket
-    ) -> PersonaConnection:
-        persona_connection = self.find_persona_connection(connection_info.persona_id)
-        if persona_connection is None:
-            persona_connection = PersonaConnection.create(connection_info, websocket)
-            self.persona_connections.append(persona_connection)
-        else:
-            persona_connection.connections.add(websocket)
-        return persona_connection
-
-    def find_persona_connection(self, persona_id: UUID) -> PersonaConnection | None:
-        return next(
-            (pc for pc in self.persona_connections if pc.persona_id == persona_id), None
-        )

--- a/hobbyroom/chat/entrypoint.py
+++ b/hobbyroom/chat/entrypoint.py
@@ -31,5 +31,3 @@ async def chat_endpoint(
             await connection_manager.receive_message(websocket, connection_info)
     except Exception:
         await connection_manager.disconnect(websocket, connection_info)
-    finally:
-        connection_manager.refresh_connections()

--- a/hobbyroom/container.py
+++ b/hobbyroom/container.py
@@ -47,7 +47,6 @@ class Container(containers.DeclarativeContainer):
     chat = providers.Container(
         ChatContainer,
         clock=clock,
-        id_generator=id_generator,
         redis_client=redis_client,
     )
     gathering = providers.Container(

--- a/hobbyroom/container.py
+++ b/hobbyroom/container.py
@@ -47,6 +47,7 @@ class Container(containers.DeclarativeContainer):
     chat = providers.Container(
         ChatContainer,
         clock=clock,
+        id_generator=id_generator,
         redis_client=redis_client,
     )
     gathering = providers.Container(

--- a/hobbyroom/container.py
+++ b/hobbyroom/container.py
@@ -1,5 +1,6 @@
 import pendulum
 from dependency_injector import containers, providers
+from redis.asyncio import ConnectionPool, Redis
 from sqlalchemy.orm import sessionmaker
 from uuid6 import uuid7
 
@@ -7,6 +8,7 @@ from hobbyroom.auth.dependency import AuthContainer
 from hobbyroom.chat.dependency import ChatContainer
 from hobbyroom.database.connection import postgres_db
 from hobbyroom.gathering.dependency import GatheringContainer
+from hobbyroom.settings import settings
 from hobbyroom.user.dependency import UserContainer
 
 
@@ -25,6 +27,13 @@ class Container(containers.DeclarativeContainer):
     db_session_factory = providers.Factory(
         lambda db_engine: sessionmaker(bind=db_engine), db_engine
     )
+    redis_pool = providers.Singleton(
+        ConnectionPool.from_url,
+        url=settings.redis_url,
+        decode_responses=True,
+        max_connections=settings.max_redis_connections,
+    )
+    redis_client = providers.Factory(Redis, connection_pool=redis_pool)
 
     id_generator = providers.Factory(lambda: uuid7)
     clock = providers.Factory(lambda: (lambda: pendulum.now("UTC")))
@@ -38,6 +47,7 @@ class Container(containers.DeclarativeContainer):
     chat = providers.Container(
         ChatContainer,
         clock=clock,
+        redis_client=redis_client,
     )
     gathering = providers.Container(
         GatheringContainer,

--- a/hobbyroom/settings.py
+++ b/hobbyroom/settings.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     redis_port: int
     redis_password: str
     redis_db: int = 0
+    max_redis_connections: int = 10
 
     jwt_secret_key: str
     jwt_algorithm: str = "HS256"

--- a/hobbyroom/settings.py
+++ b/hobbyroom/settings.py
@@ -8,6 +8,11 @@ class Settings(BaseSettings):
     db_name: str
     db_url: str
 
+    redis_host: str
+    redis_port: int
+    redis_password: str
+    redis_db: int = 0
+
     jwt_secret_key: str
     jwt_algorithm: str = "HS256"
     jwt_expiration_minutes: int = 60
@@ -21,6 +26,10 @@ class Settings(BaseSettings):
     @property
     def jwt_expiration_timedelta(self) -> pendulum.Duration:
         return pendulum.Duration(minutes=self.jwt_expiration_minutes)
+
+    @property
+    def redis_url(self) -> str:
+        return f"redis://:{self.redis_password}@{self.redis_host}:{self.redis_port}/{self.redis_db}"
 
 
 settings = Settings()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pydantic-settings>=2.10.1",
     "pyjwt>=2.10.1",
     "python-dotenv>=1.1.1",
+    "redis>=6.4.0",
     "sqlalchemy>=2.0.41",
     "uuid6>=2025.0.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -275,6 +275,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "redis" },
     { name = "sqlalchemy" },
     { name = "uuid6" },
 ]
@@ -299,6 +300,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "redis", specifier = ">=6.4.0" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "uuid6", specifier = ">=2025.0.1" },
 ]
@@ -695,6 +697,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 요약
Redis를 사용해서 여러대의 서버를 운영하더라도 일관된 채팅 연결 정보 관리가 이루어질 수 있도록 하고 pub/sub을 사용하여 여러 서버로 채팅 메시지가 발행될 수 있도록 합니다.

## 변경사항
- redis 컨테이너를 정의하고 redis python 패키지를 추가합니다.
- 채팅 연결 정보를 관리하는 `RedisConnectionRepository`를 정의합니다.
- `ConnectionManager`를 통해 채팅 연결 및 메시지 송수신, 연결 해제 하는 과정을 수정합니다.
  - 서버 어플리케이션 실행 시 FastAPI Lifespan 이벤트를 통해 `ConnectionManager` 인스턴스 및 `redis.PubSub` 인스턴스를 초기화합니다.
  - 초기화 된 `ConnectionManager` 인스턴스는 백그라운드 태스크로 구독한 redis 채널에서 메시지를 수신할 수 있도록 합니다.

## TODO
- `ConnectionManager` 내 메소드들의 책임을 분리하는 리팩토링
- Redis pub/sub 채널 관리 개선
- 로깅 및 에러 핸들링 개선